### PR TITLE
Restrict docker build workflow to main branch and release tags only

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -4,12 +4,8 @@ on:
   push:
     branches:
       - main
-      - develop
     tags:
       - 'v*'
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary

Fix GitHub Action configuration to prevent docker build and push operations from running during PR stage. The workflow now only triggers on:
- Push to main branch
- Push of release tags (v*)
- Manual workflow dispatch

## Changes

- Remove \`pull_request\` trigger from workflow
- Remove \`develop\` branch from push triggers
- Keep \`workflow_dispatch\` for manual triggering

## Test plan

- [x] Verify workflow configuration syntax
- [ ] Confirm workflow does not trigger on PR creation/update
- [ ] Confirm workflow triggers on push to main branch
- [ ] Confirm workflow triggers on release tag push