### PR TITLE
Add git-commit skill for staging, committing, and pushing changes

### DIFF
--- a/skills/git-commit/SKILL.md
+++ b/skills/git-commit/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: git-commit
+description: Stages all changes, creates a commit with a meaningful message, and pushes to the remote. Use when the user wants to commit and push their work.
+disable-model-invocation: true
+context: fork
+---
+
+# Git Commit and Push
+
+Stages changes, commits with a descriptive message, and pushes to the remote repository.
+
+## Current State
+
+Git status:
+!`git status --short`
+
+Recent commits for style reference:
+!`git log --oneline -5`
+
+Current branch:
+!`git branch --show-current`
+
+Diff of changes:
+!`git diff --stat`
+
+## Instructions
+
+1. Review the changes shown above
+2. Stage all changes using `git add -A`
+3. Create a commit with a clear, descriptive message that:
+   - Uses imperative mood (e.g., "Add feature" not "Added feature")
+   - Is concise but descriptive
+   - Follows the style of recent commits if a pattern exists
+4. Push to the remote using `git push`
+
+If the branch has no upstream, use:
+```bash
+git push -u origin $(git branch --show-current)
+```
+
+## Prerequisites
+
+- Must be run in a git repository
+- Must have changes to commit
+- Must have push access to the remote


### PR DESCRIPTION
## Summary
Add a new `git-commit` skill that automates the git workflow of staging changes, creating a commit with a meaningful message, and pushing to the remote repository.

**Key features:**
- Automatically stages all changes with `git add -A`
- Generates descriptive commit messages following imperative mood convention
- Matches existing commit style by analyzing recent commits
- Handles branches without upstream by setting up tracking automatically
- Includes context about current git status, recent commits, and diff statistics

## Test plan
- [ ] Verify skill loads correctly when invoked
- [ ] Test with unstaged changes to confirm staging works
- [ ] Test commit message generation follows imperative mood
- [ ] Test push to remote with existing upstream
- [ ] Test push to remote without upstream (should use `-u origin` flag)
- [ ] Verify skill fails gracefully when run outside a git repository