### PR TITLE
Add dynamic PR template loading from .github/PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/setup/python/setup-repo.py
+++ b/setup/python/setup-repo.py
@@ -11,6 +11,20 @@ def run(cmd, check=True):
     return result
 
 
+def get_pr_template():
+    """Read PR template from .github/PULL_REQUEST_TEMPLATE.md if it exists."""
+    template_path = "/home/agent/workspace/.github/PULL_REQUEST_TEMPLATE.md"
+    if os.path.exists(template_path):
+        with open(template_path, "r") as f:
+            return f.read()
+    return """## Summary
+<N/A>
+
+## Test plan
+- [ ] Review and test changes
+"""
+
+
 def main():
     git_repo_url = os.environ["GIT_REPO_URL"]
     pr_title = os.environ["PR_TITLE"]
@@ -72,13 +86,7 @@ def main():
                 run(f"git push -u origin {branch_name}")
 
                 print("Creating pull request")
-                pr_body = """## Summary
-<N/A>
-
-## Test plan
-- [ ] Review and test changes
-
-"""
+                pr_body = get_pr_template()
                 result = run(f"gh pr create --title '{pr_title}' --body '{pr_body}'")
                 pr_url = result.stdout.strip()
 


### PR DESCRIPTION
## Summary
- Add `get_pr_template()` function to read PR template from `.github/PULL_REQUEST_TEMPLATE.md`
- Replace hardcoded PR body with dynamic template loading
- Falls back to default template if file does not exist

## Test plan
- [ ] Verify PR creation uses template from `.github/PULL_REQUEST_TEMPLATE.md` when present
- [ ] Verify fallback to default template when template file is missing