### PR TITLE
Add get-pr-details skill for fetching PR information via GitHub CLI

### DIFF
--- a/skills/get-pr-details/SKILL.md
+++ b/skills/get-pr-details/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: get-pr-details
+description: Gets details of a GitHub pull request including title, description, and file changes. Use when the user wants to view PR information.
+disable-model-invocation: true
+context: fork
+---
+
+# Get PR Details
+
+Retrieves and displays pull request information including title, description, and changed files.
+
+## PR Information
+
+Title:
+!`gh pr view --json title -q .title`
+
+Description:
+!`gh pr view --json body -q .body`
+
+Changed files:
+!`gh pr view --json files -q '.files[].path'`
+
+## Instructions
+
+Display the PR information shown above to the user in a clear format.


### PR DESCRIPTION
## Summary

Adds a new skill for retrieving GitHub pull request details, enabling users to quickly view PR information including title, description, and changed files.

## Changes

- Add `skills/get-pr-details/SKILL.md` - A new skill that uses the GitHub CLI to fetch and display PR information
  - Retrieves PR title via `gh pr view --json title`
  - Retrieves PR description via `gh pr view --json body`
  - Lists changed files via `gh pr view --json files`
  - Uses `disable-model-invocation: true` for direct execution without additional model processing
  - Uses `context: fork` to run in a forked context

## Testing

- [ ] Tests pass locally
- [ ] Manual testing completed
  - Verify skill can be invoked via `/get-pr-details`
  - Confirm PR information is displayed correctly

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented if unavoidable)