### PR TITLE
Switch PR update skills from gh pr edit to gh api REST endpoints

### DIFF
--- a/skills/update-pr-summary/SKILL.md
+++ b/skills/update-pr-summary/SKILL.md
@@ -15,7 +15,7 @@ Analyzes the current pull request changes and generates an improved summary/desc
 2. **Analyzes changes**: Reviews the diff to understand what was modified
 3. **Checks for template**: Looks for pull_request_template.md to follow the project's format
 4. **Generates improved summary**: Creates a better description based on the actual changes
-5. **Updates the PR**: Uses `gh api` GraphQL mutation to update the PR description
+5. **Updates the PR**: Uses `gh api` REST API to update the PR description
 
 ## Current PR Information
 

--- a/skills/update-pr-title/SKILL.md
+++ b/skills/update-pr-title/SKILL.md
@@ -14,7 +14,7 @@ Analyzes the pull request changes and summary to generate an improved title.
 1. **Fetches PR information**: Gets the current PR title, description, and metadata
 2. **Analyzes changes**: Reviews the diff to understand what was modified
 3. **Generates improved title**: Creates a concise, descriptive title based on the changes and summary
-4. **Updates the PR**: Uses `gh api` GraphQL mutation to update the PR title
+4. **Updates the PR**: Uses `gh api` REST API to update the PR title
 
 ## Current PR Information
 


### PR DESCRIPTION
## Summary

Updates the PR update skills to use `gh api` REST API instead of `gh pr edit` for modifying PR descriptions and titles. This change provides a more reliable method for updating PR metadata that avoids issues with the GraphQL API related to deprecated Projects Classic features.

## Changes

- Modified `skills/update-pr-summary/SKILL.md` to use `gh api repos/:owner/:repo/pulls/... -X PATCH -f body=` instead of `gh pr edit --body`
- Modified `skills/update-pr-title/SKILL.md` to use `gh api repos/:owner/:repo/pulls/... -X PATCH -f title=` instead of `gh pr edit --title`

## Testing

- [ ] Tests pass locally
- [x] Manual testing completed

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented if unavoidable)