### PR TITLE
add claude json in home folder explain in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Coder solves this by running Claude Code in an isolated Docker container where i
 - Docker
 - GitHub CLI (`gh`) authenticated
 - Claude Code settings (`~/.claude_in_docker/settings.json`) with API key configured
+- `~/.claude_in_docker.json` - Auto-generated on first run to store configuration and skip setup on subsequent runs
 
 ### Usage
 


### PR DESCRIPTION
## Summary

This PR updates the README documentation to clarify that `~/.claude_in_docker.json` is automatically generated on first run, eliminating confusion about manual setup requirements.

## Changes

- Updated Prerequisites section in README.md to document the `~/.claude_in_docker.json` file
- Added clarification that this configuration file is auto-generated on first run
- Explained that the file stores configuration and skips setup on subsequent runs

## Impact

This documentation improvement helps users understand that they do not need to manually create the `~/.claude_in_docker.json` file - it will be created automatically when they first run Coder. This reduces potential setup confusion and aligns the documentation with the actual behavior implemented in PR #14.

## Testing

- [x] Documentation changes reviewed for accuracy
- [x] Verified against actual implementation behavior