### PR TITLE
Remove ambiguous semver tags from Docker image versioning

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -46,10 +46,8 @@ jobs:
             type=ref,event=branch
             # Tag with PR number
             type=ref,event=pr
-            # Tag with git tag (semver)
+            # Tag with git tag (semver) - only full version
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## Summary

This PR fixes the Docker image tagging strategy in the CI workflow to prevent creating ambiguous version tags when release tags are pushed. Previously, when a version like `v1.0.0` was tagged, the workflow would create three separate tags: `1.0.0`, `1.0`, and `1`. This caused issues with image versioning and made it unclear which image corresponded to which exact release.

## Changes

- **Removed ambiguous semver tag patterns** from `.github/workflows/docker-build-push.yml`:
  - Removed `type=semver,pattern={{major}}.{{minor}}` (e.g., `1.0`)
  - Removed `type=semver,pattern={{major}}` (e.g., `1`)
- **Kept only the full version tag**: `type=semver,pattern={{version}}` (e.g., `1.0.0`)
- Updated inline comment to clarify the tagging behavior: "Tag with git tag (semver) - only full version"

## Impact

- **Before**: Pushing tag `v1.0.0` would create Docker images tagged as `1.0.0`, `1.0`, and `1`
- **After**: Pushing tag `v1.0.0` will only create a Docker image tagged as `1.0.0`

This ensures each release has a single, unambiguous tag in the container registry (GHCR), making it easier to track and reference specific versions.

## Testing

- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] Verified workflow syntax is valid

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated (inline comments)
- [x] No breaking changes (existing images remain unaffected)