### PR TITLE
Add host network mode to Docker run in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ run:
 	export GIT_USER_EMAIL="$$(git config user.email)" && \
 	[ -f ~/.claude_in_docker.json ] || echo '{}' > ~/.claude_in_docker.json && \
 	docker run --rm --pull always \
+		--network host \
 		-it \
 		-v ~/.claude_in_docker:/home/agent/.claude \
 		-v ~/.claude_in_docker.json:/home/agent/.claude.json \


### PR DESCRIPTION
## Summary

This PR adds `--network host` mode to the Docker run command in the Makefile, enabling the container to use the host's network stack directly instead of Docker's default bridge networking.

## Changes

- Added `--network host` flag to the `docker run` command in the `make run` target

## Why This Change?

Using host networking mode provides several benefits:
- **Direct network access**: The container can access services running on localhost without port mapping
- **Simplified networking**: No need to expose/map individual ports with `-p` flags
- **Better performance**: Eliminates the network translation overhead of bridge networking
- **Local service integration**: Allows the containerized application to seamlessly interact with services running on the host machine

This is particularly useful when the containerized application needs to communicate with local development services (databases, APIs, etc.) or when running in environments where bridge networking creates connectivity issues.

## Testing

- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] Verified container can access host network services

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or documented if unavoidable)

## Notes

**Compatibility**: The `--network host` option only works on Linux hosts. On macOS and Windows, Docker Desktop uses a VM, so host networking behaves differently. Users on non-Linux platforms may need to use alternative networking configurations.