### PR TITLE
Fix PR template detection to prioritize uppercase filename

### DIFF
--- a/skills/update-pr-summary/SKILL.md
+++ b/skills/update-pr-summary/SKILL.md
@@ -27,7 +27,7 @@ PR diff:
 
 ## Template Format
 
-!`if [ -f .github/pull_request_template.md ]; then cat .github/pull_request_template.md; elif [ -f pull_request_template.md ]; then cat pull_request_template.md; else echo "No template found"; fi`
+!`if [ -f .github/PULL_REQUEST_TEMPLATE.md ]; then cat .github/PULL_REQUEST_TEMPLATE.md; elif [ -f .github/pull_request_template.md ]; then cat .github/pull_request_template.md; elif [ -f pull_request_template.md ]; then cat pull_request_template.md; else echo "No template found"; fi`
 
 ## Instructions
 


### PR DESCRIPTION
## Summary

This PR fixes the update-pr-summary skill to properly detect GitHub pull request templates by checking for the uppercase `PULL_REQUEST_TEMPLATE.md` filename variant first, which is the more common convention used by GitHub.

## Changes

- Updated the template detection logic in `skills/update-pr-summary/SKILL.md` to check for `.github/PULL_REQUEST_TEMPLATE.md` (uppercase) before checking the lowercase variant
- Reordered the conditional checks to prioritize the uppercase naming convention, which is GitHub's recommended format

## Testing

- [x] Verified the skill now correctly detects PR templates with uppercase filenames
- [x] Confirmed backward compatibility with lowercase template filenames
- [x] Manual testing completed with the current repository's PR template

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented if unavoidable)