### PR TITLE
Use repository name for working directory instead of hardcoded workspace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ PR_NUMBER ?=
 PR_TITLE ?=
 CODEMATE_IMAGE ?=
 
+# Extract repo name from git URL
+REPO_NAME := $(shell echo $(GIT_REPO_URL) | sed 's/\.git$$//' | sed 's|.*/||')
+
 .PHONY: run
 
 run:
@@ -25,5 +28,5 @@ run:
 		-e GIT_USER_NAME \
 		-e GIT_USER_EMAIL \
 		--env-file .env \
-		-w /home/agent/workspace \
+		-w /home/agent/$(REPO_NAME) \
 		$${CODEMATE_IMAGE:-ghcr.io/boringhappy/codemate:main} $(extra)


### PR DESCRIPTION
## Summary

This PR updates the working directory structure to use the actual GitHub repository name instead of a hardcoded "workspace" directory. This change makes the setup more flexible and allows multiple repositories to coexist without conflicts.

## Changes

- **Makefile**: Added logic to extract repository name from `GIT_REPO_URL` and use it as the working directory path (`/home/agent/<repo-name>` instead of `/home/agent/workspace`)
- **setup-repo.py**: 
  - Added `get_repo_name_from_url()` function to parse repository name from git URLs (supports both HTTPS and SSH formats)
  - Updated workspace path to use the extracted repository name
  - Modified `get_pr_template()` to accept workspace path as a parameter instead of using hardcoded path
  - Updated git clone command to use the repository name as the target directory

## Impact

- Enables running multiple repository setups simultaneously without directory conflicts
- Makes the codebase more maintainable by removing hardcoded paths
- Improves flexibility for different repository configurations
- No breaking changes for existing workflows (environment variables remain the same)

## Testing

- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] Verified repository name extraction works for both HTTPS and SSH git URLs
- [ ] Confirmed PR template detection works with dynamic workspace path

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented if unavoidable)