### PR TITLE
Add local Docker image build and run support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM docker/sandbox-templates:claude-code
+ARG BASE_IMAGE=docker/sandbox-templates:claude-code
+FROM ${BASE_IMAGE}
 
 # Install zsh and dependencies
 USER root


### PR DESCRIPTION
## Summary

This PR adds support for building and running CodeMate from a local Docker image with a configurable base image. This enables developers to test changes locally before pushing to the registry and allows customization of the base sandbox image.

## Changes

- **Dockerfile**: Made the base image configurable via `BASE_IMAGE` build argument (defaults to `docker/sandbox-templates:claude-code`)
- **Makefile**: Added two new targets:
  - `build`: Builds a local Docker image with configurable base image and tag
  - `run-local`: Runs the locally built image instead of pulling from the registry
- Both new targets support the same environment variable configuration as the existing `run` target

## Testing

- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] Verify `make build` successfully builds the image
- [ ] Verify `make run-local` runs the locally built image
- [ ] Verify `BASE_IMAGE` and `LOCAL_IMAGE_TAG` variables work as expected

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented if unavoidable)