### PR TITLE
Add update-pr skill for combined title and summary updates

### DIFF
--- a/skills/update-pr/SKILL.md
+++ b/skills/update-pr/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: update-pr
+description: Updates both the summary/description and title of a GitHub pull request by analyzing the changes. Use when the user wants to improve or regenerate their PR description and title together.
+disable-model-invocation: true
+context: fork
+---
+
+# Update PR Summary and Title
+
+Analyzes the current pull request changes and generates an improved summary/description and title.
+
+## What it does
+
+1. **Fetches PR information**: Gets the current PR title, description, and metadata
+2. **Analyzes changes**: Reviews the diff to understand what was modified
+3. **Checks for template**: Looks for pull_request_template.md to follow the project's format
+4. **Generates improved summary**: Creates a better description based on the actual changes
+5. **Generates improved title**: Creates a concise, descriptive title based on the changes
+6. **Updates the PR**: Uses `gh api` REST API to update both the PR description and title
+
+## Current PR Information
+
+Current title:
+!`gh pr view --json title -q .title`
+
+Current description:
+!`gh pr view --json body -q .body`
+
+PR diff:
+!`gh pr diff`
+
+Files changed:
+!`gh pr diff --name-only`
+
+## Template Format
+
+!`if [ -f .github/PULL_REQUEST_TEMPLATE.md ]; then cat .github/PULL_REQUEST_TEMPLATE.md; elif [ -f .github/pull_request_template.md ]; then cat .github/pull_request_template.md; elif [ -f pull_request_template.md ]; then cat pull_request_template.md; else echo "No template found"; fi`
+
+## Instructions
+
+Based on the PR diff and current information above:
+
+### For the Summary
+Create an improved PR summary that:
+- Accurately describes what changes were made and why
+- Follows the template format if one exists
+- Is clear, concise, and informative
+- Highlights the key changes and their impact
+- Includes relevant technical details
+
+### For the Title
+Create an improved PR title that:
+- Is concise (typically 50-72 characters)
+- Clearly describes the main change or feature
+- Follows conventional commit style if the project uses it
+- Is written in imperative mood (e.g., "Add feature" not "Added feature")
+- Captures the essence of all changes
+
+### Updating the PR
+
+After generating both the improved summary and title, update the PR using a single API call:
+```bash
+gh api repos/:owner/:repo/pulls/$(gh pr view --json number -q .number) -X PATCH -f title="Your improved title here" -f body='Your improved summary here'
+```
+
+Alternatively, you can update them separately:
+```bash
+# Update title
+gh api repos/:owner/:repo/pulls/$(gh pr view --json number -q .number) -X PATCH -f title="Your improved title here"
+
+# Update summary
+gh api repos/:owner/:repo/pulls/$(gh pr view --json number -q .number) -X PATCH -f body='Your improved summary here'
+```
+
+## Prerequisites
+
+- Must be run in a git repository with an active pull request
+- GitHub CLI (`gh`) must be installed and authenticated
+- Must have write access to the repository


### PR DESCRIPTION
## Summary

Adds a new skill that extends PR update functionality to modify both the title and description in a single operation. This provides a more complete PR refinement workflow compared to updating just the description.

## Changes

- Add `skills/update-pr/SKILL.md` with combined title and summary update capability
- Include instructions for generating concise, conventional commit-style titles
- Support both single API call (updating title and body together) and separate update approaches
- Maintain template format compatibility for PR descriptions

## Testing

- [ ] Tests pass locally
- [x] Manual testing completed

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented if unavoidable)