### PR TITLE
Pass system prompt content as string instead of file path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,4 @@ USER agent
 COPY skills /home/agent/.claude/skills
 
 ENTRYPOINT ["/usr/local/bin/setup/setup.sh"]
-CMD ["claude", "--dangerously-skip-permissions", "--append-system-prompt", "/usr/local/bin/setup/prompt/system_prompt.txt"]
+CMD ["sh", "-c", "claude --dangerously-skip-permissions --append-system-prompt \"$(cat /usr/local/bin/setup/prompt/system_prompt.txt)\""]


### PR DESCRIPTION
## Summary

Changes the Docker CMD to pass the system prompt file contents directly to Claude CLI instead of passing the file path. This ensures the `--append-system-prompt` flag receives the actual prompt text rather than a path reference.

## Changes

- Modified Dockerfile CMD to use shell command substitution (`$(cat ...)`) to read the system prompt file
- Wrapped the command in `sh -c` to enable shell expansion for the `cat` subcommand
- The prompt content is now passed as a string argument rather than a file path

## Testing

- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] Docker image builds successfully
- [ ] Claude CLI receives the system prompt content correctly

## Checklist

- [ ] Code follows project conventions
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or documented if unavoidable)