### PR TITLE
Remove hooks configuration from settings.json.example

### DIFF
--- a/settings.json.example
+++ b/settings.json.example
@@ -1,7 +1,7 @@
 {
   "env": {
     "ANTHROPIC_AUTH_TOKEN": "<fill yours token>",
-    "ANTHROPIC_BASE_URL": "<fill yours token>",
+    "ANTHROPIC_BASE_URL": "fill your base_url",
     "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
   },
   "attribution": {


### PR DESCRIPTION
## Summary

Removes the hooks configuration from `settings.json.example` to simplify the example settings file and eliminate automated session hooks.

## Changes

- Removed `SessionStart` hook that automatically fetched PR details via `gh pr view`
- Removed `Stop` hook that prompted to commit uncommitted changes using the git-commit skill
- Cleaned up trailing formatting (removed trailing newline)

## Testing

- [ ] Tests pass locally
- [x] Manual testing completed

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented if unavoidable)