### PR TITLE
Fix Docker image name case sensitivity in GitHub Actions workflow

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -10,7 +10,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
@@ -32,6 +31,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set lowercase image name
+        id: image
+        run: echo "name=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -47,7 +50,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}
           tags: |
             # Tag with branch name (main branch gets 'main' tag only)
             type=ref,event=branch
@@ -65,7 +68,7 @@ jobs:
           file: ./Dockerfile
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ steps.image.outputs.name }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -105,6 +108,10 @@ jobs:
           pattern: digests-*
           merge-multiple: true
 
+      - name: Set lowercase image name
+        id: image
+        run: echo "name=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
       - name: Verify all platforms built
         run: |
           digest_count=$(ls /tmp/digests | wc -l)
@@ -128,7 +135,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}
           tags: |
             # Tag with branch name (main branch gets 'main' tag only)
             type=ref,event=branch
@@ -142,4 +149,4 @@ jobs:
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+            $(printf '${{ env.REGISTRY }}/${{ steps.image.outputs.name }}@sha256:%s ' *)


### PR DESCRIPTION
## Summary

This PR fixes a case sensitivity issue in the Docker build workflow that was causing failures when pushing images to GitHub Container Registry (GHCR). The repository name contains uppercase letters, but GHCR requires lowercase image names.

## Changes

- Removed the hardcoded `IMAGE_NAME` environment variable that used `github.repository` directly
- Added a new step to convert the repository name to lowercase using `tr '[:upper:]' '[:lower:]'`
- Updated all references to use the lowercase image name from the step output
- Applied the fix to both the build job and the merge job to ensure consistency across the entire workflow

## Testing

- [x] Workflow will be tested when this PR is merged to main
- [x] Changes follow GitHub Actions best practices for multi-platform Docker builds
- [x] All image name references updated consistently

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented if unavoidable)