### PR TITLE
Install Playwright browsers in Docker image for agent-browser support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,10 @@ RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
 RUN npm install -g agent-browser \
     && agent-browser install --with-deps
 
+# Install Playwright browsers and system dependencies
+RUN npx playwright install chromium \
+    && npx playwright install-deps chromium
+
 # Install Oh My Zsh for agent user
 USER agent
 RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended


### PR DESCRIPTION
## Summary

This PR adds Playwright browser installation to the Docker image to ensure agent-browser has the necessary browser binaries and system dependencies to function properly in the containerized environment.

## Changes

- Added `npx playwright install chromium` to install the Chromium browser binary
- Added `npx playwright install-deps chromium` to install required system dependencies for Chromium
- Installation occurs after agent-browser npm package installation in the Dockerfile

## Testing

- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] Verify agent-browser can launch Chromium successfully in container
- [ ] Confirm no missing system dependencies errors

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or documented if unavoidable)