### PR TITLE
Fix Playwright browser installation order in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,12 +20,14 @@ RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
 RUN npm install -g agent-browser \
     && agent-browser install --with-deps
 
-# Install Playwright browsers and system dependencies
-RUN npx playwright install chromium \
-    && npx playwright install-deps chromium
+# Install Playwright system dependencies as root
+RUN npx playwright install-deps chromium
 
 # Install Oh My Zsh for agent user
 USER agent
+
+# Install Playwright browsers as agent user (user-specific cache)
+RUN npx playwright install chromium
 RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
 
 # Set ys theme in .zshrc


### PR DESCRIPTION
## Summary

This PR fixes the Playwright browser installation in the Docker image by ensuring browsers are installed in the correct user context. Previously, Playwright browsers were installed as root before switching to the agent user, which could cause permission issues since Playwright stores browsers in a user-specific cache directory.

## Changes

- Moved `npx playwright install chromium` to run as the agent user (after `USER agent`)
- Kept `npx playwright install-deps chromium` as root since system dependencies require elevated privileges
- Added clarifying comments to distinguish between system dependencies (root) and browser binaries (agent user)
- Reordered commands to ensure proper user context for each installation step

## Testing

- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] Docker image builds successfully
- [ ] agent-browser skill works correctly in container

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented if unavoidable)