### PR TITLE
Add proxy support for agent-browser via environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,9 @@ RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master
 # Set ys theme in .zshrc
 RUN sed -i 's/ZSH_THEME="robbyrussell"/ZSH_THEME="ys"/g' /home/agent/.zshrc
 
+# Add agent-browser wrapper function to use proxy from environment variable when set
+RUN echo 'agent-browser() { if [ -n "$HTTPS_PROXY" ]; then command agent-browser --proxy "$HTTPS_PROXY" "$@"; else command agent-browser "$@"; fi; }' >> /home/agent/.zshrc
+
 # Set zsh as default shell
 USER root
 RUN chsh -s $(which zsh) agent


### PR DESCRIPTION
## Summary

Adds automatic proxy support for the `agent-browser` tool by creating a shell wrapper function that passes the `HTTPS_PROXY` environment variable when set.

## Changes

- Added a zsh wrapper function for `agent-browser` in the Dockerfile
- The wrapper automatically detects if `HTTPS_PROXY` is set and passes it via the `--proxy` flag
- When no proxy is configured, the command runs normally without modification

## Testing

- [ ] Tests pass locally
- [ ] Manual testing completed
  - [ ] Verify agent-browser works without proxy when `HTTPS_PROXY` is unset
  - [ ] Verify agent-browser uses proxy when `HTTPS_PROXY` is set

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented if unavoidable)