### PR TITLE
Add colored output to container status messages in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,10 +50,11 @@ endef
 # Usage: $(call run_or_attach,<image>,<extra_flags>)
 define run_or_attach
 	@if docker ps --format '{{.Names}}' | grep -q "^$(CONTAINER_NAME)$$"; then \
-		echo "Container $(CONTAINER_NAME) is running. Attaching..."; \
+		echo -e "\033[0;32mContainer $(CONTAINER_NAME) is running.\033[0m"; \
+		echo -e "\033[0;36mAttaching zsh...\033[0m"; \
 		docker exec -it $(CONTAINER_NAME) zsh; \
 	else \
-		echo "Creating new container $(CONTAINER_NAME)..."; \
+		echo -e "\033[0;33mCreating new container $(CONTAINER_NAME)...\033[0m"; \
 		$(call docker_run,$(2),$(1)); \
 	fi
 endef


### PR DESCRIPTION
## Summary

This PR enhances the user experience when running `make run` or `make run-local` commands by adding colored terminal output to container status messages. The colored output makes it easier to distinguish between different states: green for attaching to existing containers, cyan for the attach action, and yellow for creating new containers.

## Changes

- Updated `run_or_attach` function in Makefile to use ANSI color codes
- Green color (`\033[0;32m`) for "Container is running" message
- Cyan color (`\033[0;36m`) for "Attaching zsh..." message  
- Yellow color (`\033[0;33m`) for "Creating new container..." message
- Improved message formatting with `echo -e` to support escape sequences

## Testing

- [x] Manual testing completed - verified colored output appears correctly when:
  - Attaching to existing container
  - Creating new container

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented if unavoidable)