### PR TITLE
Add custom Docker image parameter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ chmod +x start.sh
 
 # Run with custom volume mounts (optional)
 ./start.sh --branch feature/xyz --mount ~/data:/data
+
+# For Chinese users: Use DaoCloud mirror for faster image pulls
+./start.sh --branch feature/xyz --image ghcr.m.daocloud.io/boringhappy/codemate:latest
 ```
 
 The script will:
@@ -87,7 +90,7 @@ Use `--mount <host-path>:<container-path>` to mount additional directories or fi
 | `GITHUB_TOKEN` | Auto | GitHub personal access token (defaults to `gh auth token` if not provided) |
 | `GIT_USER_NAME` | Auto | Git commit author name (defaults to `git config user.name` if not provided) |
 | `GIT_USER_EMAIL` | Auto | Git commit author email (defaults to `git config user.email` if not provided) |
-| `CODEMATE_IMAGE` | No | Custom image (default: `ghcr.io/boringhappy/codemate:main`) |
+| `CODEMATE_IMAGE` | No | Custom image (default: `ghcr.io/boringhappy/codemate:latest`) |
 
 
 ## How It Works

--- a/start.sh
+++ b/start.sh
@@ -17,7 +17,7 @@ GIT_REPO_URL="${GIT_REPO_URL:-$(git config --get remote.origin.url 2>/dev/null |
 BRANCH_NAME="${BRANCH_NAME:-}"
 PR_NUMBER="${PR_NUMBER:-}"
 PR_TITLE="${PR_TITLE:-}"
-CODEMATE_IMAGE="${CODEMATE_IMAGE:-ghcr.io/boringhappy/codemate:main}"
+CODEMATE_IMAGE="${CODEMATE_IMAGE:-ghcr.io/boringhappy/codemate:latest}"
 
 # Function to print colored messages
 print_info() {
@@ -353,6 +353,7 @@ Options:
   --pr-title TITLE     PR title (optional)
   --repo URL           Git repository URL
   --mount PATH:PATH    Custom volume mount (can be used multiple times)
+  --image IMAGE        Docker image to use (default: ghcr.io/boringhappy/codemate:latest)
   --help               Show this help message
 
 Environment Variables:
@@ -363,6 +364,7 @@ Environment Variables:
   GITHUB_TOKEN         GitHub personal access token
   GIT_USER_NAME        Git commit author name
   GIT_USER_EMAIL       Git commit author email
+  CODEMATE_IMAGE       Docker image to use (default: ghcr.io/boringhappy/codemate:latest)
 
 Examples:
   # First time setup
@@ -383,6 +385,9 @@ Examples:
   # Run with custom volume mounts
   $0 --branch feature/xyz --mount /local/path:/container/path
   $0 --branch feature/xyz --mount ~/data:/data --mount ~/config:/config
+
+  # Run with custom image
+  $0 --branch feature/xyz --image ghcr.io/boringhappy/codemate:v1.0.0
 
 EOF
 }
@@ -421,6 +426,10 @@ main() {
                 ;;
             --mount)
                 custom_mounts+=("$2")
+                shift 2
+                ;;
+            --image)
+                CODEMATE_IMAGE="$2"
                 shift 2
                 ;;
             --help)


### PR DESCRIPTION
## Summary

This PR adds support for specifying a custom Docker image when running CodeMate, making it easier for users in different regions to use alternative container registries (e.g., DaoCloud mirror for Chinese users) or specific image versions.

## Changes

- Added `--image` parameter to `start.sh` to allow custom Docker image specification
- Updated default image tag from `main` to `latest` for better semantic versioning
- Added documentation for the new `--image` parameter in help text and README
- Included example usage for Chinese users to use DaoCloud mirror registry

## Testing

- [ ] Tests pass locally
- [ ] Manual testing completed

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated (if applicable)
- [ ] No breaking changes (or documented if unavoidable)