### PR TITLE
Fix unknown/unknown architecture in multi-arch Docker manifest

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -74,6 +74,7 @@ jobs:
           outputs: type=image,name=${{ env.REGISTRY }}/${{ steps.image.outputs.name }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: false
 
       - name: Export digest
         if: github.event_name != 'pull_request'
@@ -84,7 +85,8 @@ jobs:
             echo "Error: No digest output from build"
             exit 1
           fi
-          touch "/tmp/digests/${digest#sha256:}"
+          # Store platform info in the digest file for manifest creation
+          echo "${{ matrix.platform }}" > "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
         if: github.event_name != 'pull_request'
@@ -151,5 +153,13 @@ jobs:
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ steps.image.outputs.name }}@sha256:%s ' *)
+          # Build source image references from digests
+          SOURCES=""
+          for digest in *; do
+            SOURCES="$SOURCES ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}@sha256:$digest"
+          done
+
+          # Create and push multi-arch manifest
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $SOURCES


### PR DESCRIPTION
## Summary

Fixes the issue where GHCR packages show `unknown/unknown` architecture entries in the multi-arch Docker manifest. This occurs because BuildKit generates provenance attestations by default, which create additional manifest entries that appear as `unknown/unknown` when `imagetools create` merges the digests.

## Changes

- Add `provenance: false` to the `docker/build-push-action` to disable attestation manifests that cause the unknown/unknown entries
- Store platform info in digest files (instead of empty files) for better debugging and verification
- Improve manifest creation script readability with explicit loop and comments

## Testing

- [ ] Tests pass locally
- [x] Manual testing completed

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or documented if unavoidable)