### PR TITLE
Clarify --tag and --image option usage in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ For development or customization, you can build CodeMate from a local Dockerfile
 - `--build` - Build Docker image from local Dockerfile before running
 - `-f, --dockerfile PATH` - Path to Dockerfile (default: `Dockerfile`)
 - `--tag TAG` - Image tag for local build (default: `codemate:local`)
+  - **Note:** Only works with `--build`. To use a pre-built image, use `--image` instead
 
 When `--build` is used:
 1. The script builds the Docker image from the specified Dockerfile

--- a/start.sh
+++ b/start.sh
@@ -392,9 +392,11 @@ Options:
   --repo URL           Git repository URL
   --mount PATH:PATH    Custom volume mount (can be used multiple times)
   --image IMAGE        Docker image to use (default: ghcr.io/boringhappy/codemate:latest)
+                       Note: Ignored when --build is used
   --build              Build Docker image from local Dockerfile
   -f, --dockerfile PATH  Path to Dockerfile (default: Dockerfile, requires --build)
-  --tag TAG            Image tag for local build (default: codemate:local, requires --build)
+  --tag TAG            Image tag for local build (default: codemate:local)
+                       Note: Only works with --build. To use a pre-built image, use --image instead
   --help               Show this help message
 
 Environment Variables:


### PR DESCRIPTION
## Summary

Improves documentation clarity for the `--tag` and `--image` options in start.sh to prevent user confusion about when each option should be used.

## Changes

- Added note to `--image` option explaining it's ignored when `--build` is used
- Enhanced `--tag` option description with clarification that it only works with `--build`
- Added guidance to use `--image` for pre-built images instead of `--tag`
- Updated both start.sh help text and README.md for consistency

## Key Points

**--tag option:**
- Only works with `--build` flag (for local image builds)
- Default value: `codemate:local`
- To use a pre-built image, use `--image` instead

**--image option:**
- Specifies which Docker image to use
- Default: `ghcr.io/boringhappy/codemate:latest`
- Ignored when `--build` is used (local build takes precedence)

## Testing

- [x] Documentation changes reviewed for accuracy
- [x] Verified code logic matches documentation (line 556 in start.sh overwrites CODEMATE_IMAGE when --build is used)

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated
- [x] No breaking changes