### PR TITLE
Remove Anthropic token/URL from settings.json and add SLACK_WEBHOOK docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ CodeMate solves this by running Claude Code in an isolated Docker container wher
 - zsh with Oh My Zsh
 - Persistent Claude configuration
 - Built-in Claude Code skills for PR workflow automation
+- Slack notifications when Claude stops (via `SLACK_WEBHOOK`)
 
 ## Quick Start
 

--- a/plugins/pr/README.md
+++ b/plugins/pr/README.md
@@ -65,52 +65,12 @@ claude --plugin-dir /path/to/pr
 - Git repository with remote access
 - Active pull request (for most skills)
 
-## Hooks
-
-### `send_to_slack.sh`
-
-A Claude Code Stop hook that sends notifications to Slack when Claude stops working. This is useful for getting notified when Claude completes a task or needs attention.
-
-**Setup:**
-
-1. Create a Slack Incoming Webhook:
-   - Go to your Slack workspace's App Directory
-   - Search for "Incoming WebHooks" and add it
-   - Choose a channel and copy the webhook URL
-
-2. Set the `SLACK_WEBHOOK` environment variable in your `.env` file:
-   ```bash
-   SLACK_WEBHOOK=https://hooks.slack.com/services/YOUR/WEBHOOK/URL
-   ```
-
-**Message Content:**
-
-The Slack notification includes:
-- Repository name
-- Branch name
-- PR link
-- PR title
-- Last commit message
-
-**Example Slack Message:**
-```
-*Repository:* my-repo
-*Branch:* feature/new-feature
-*PR Link:* https://github.com/user/my-repo/pull/123
-*PR Title:* Add new feature
-*Commit:* Fix bug in authentication flow
-```
-
-**Note:** If `SLACK_WEBHOOK` is not set, the hook exits silently without sending any notification.
-
 ## Plugin Structure
 
 ```
 pr/
 ├── .claude-plugin/
 │   └── plugin.json          # Plugin manifest
-├── hooks/
-│   └── send_to_slack.sh     # Slack notification hook
 └── skills/
     ├── get-details/
     │   └── SKILL.md


### PR DESCRIPTION
## Summary

Remove hardcoded Anthropic API configuration placeholders from the generated `settings.json` file and add documentation for the `SLACK_WEBHOOK` environment variable.

## Changes

- Remove `ANTHROPIC_AUTH_TOKEN` and `ANTHROPIC_BASE_URL` placeholders from `create_settings_json()` in `start.sh`
- Add `SLACK_WEBHOOK` to the Features section in README.md
- Add `SLACK_WEBHOOK` to the Environment Variables table in README.md
- Add `SLACK_WEBHOOK` to the help text in `start.sh`

## Testing

- [x] Manual testing completed

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented if unavoidable)