### PR TITLE
Fix plugin setup to handle partial installations

### DIFF
--- a/setup/shell/common.sh
+++ b/setup/shell/common.sh
@@ -27,12 +27,19 @@ run_setup_script() {
     fi
 }
 
-# Function to add a Claude plugin marketplace
+# Function to add a Claude plugin marketplace (checks if already added)
 # Usage: add_marketplace "index/total" "marketplace-name" "marketplace-path"
 add_marketplace() {
     local progress="$1"
     local name="$2"
     local path="$3"
+
+    # Check if marketplace is already added
+    local existing_marketplaces=$(claude plugin marketplace list 2>/dev/null || echo "")
+    if echo "$existing_marketplaces" | grep -q "$path"; then
+        printf "  [${progress}] ${GREEN}✓ ${name} marketplace already added${RESET}\n"
+        return 0
+    fi
 
     printf "  [${progress}] Adding ${name} marketplace...\n"
     if claude plugin marketplace add "$path" 2>&1; then
@@ -44,19 +51,29 @@ add_marketplace() {
     fi
 }
 
-# Function to install and verify a Claude plugin
+# Function to install and verify a Claude plugin (checks if already installed)
 # Usage: install_and_verify_plugin "index/total" "plugin-name" "skill1, skill2, skill3"
 install_and_verify_plugin() {
     local progress="$1"
     local plugin="$2"
     local skills="$3"
 
+    # Check if plugin is already installed
+    local installed_list=$(claude plugin list 2>/dev/null || echo "")
+    if echo "$installed_list" | grep -q "$plugin"; then
+        printf "  [${progress}] ${GREEN}✓ ${plugin} already installed${RESET}\n"
+        if [ -n "$skills" ]; then
+            printf "    Skills: ${skills}\n"
+        fi
+        return 0
+    fi
+
     printf "  [${progress}] Installing ${plugin}...\n"
     if claude plugin install "$plugin" 2>&1; then
         printf "  ${GREEN}✓ ${plugin} installed${RESET}\n"
 
         # Verify installation
-        local installed_list=$(claude plugin list 2>/dev/null || echo "")
+        installed_list=$(claude plugin list 2>/dev/null || echo "")
         if echo "$installed_list" | grep -q "$plugin"; then
             if [ -n "$skills" ]; then
                 printf "    Skills: ${skills}\n"

--- a/setup/shell/setup-plugins.sh
+++ b/setup/shell/setup-plugins.sh
@@ -12,72 +12,15 @@ printf "  Creating temp directory at /home/agent/.claude/tmp\n"
 mkdir -p /home/agent/.claude/tmp
 export TMPDIR=/home/agent/.claude/tmp
 
-# Check which plugins are already installed
-printf "\n${CYAN}Checking existing plugins...${RESET}\n"
-EXISTING_PLUGINS=$(claude plugin list 2>/dev/null || echo "")
+# Add marketplaces (functions check if already added)
+printf "\n${CYAN}Adding marketplaces:${RESET}\n"
+add_marketplace "1/2" "vercel-labs/agent-browser" "vercel-labs/agent-browser"
+add_marketplace "2/2" "codemate" "BoringHappy/CodeMate"
 
-# Track which plugins need to be installed
-NEED_AGENT_BROWSER=true
-NEED_GIT=true
-NEED_PR=true
-
-if echo "$EXISTING_PLUGINS" | grep -q "agent-browser@agent-browser"; then
-    printf "  ${GREEN}✓ agent-browser@agent-browser already installed${RESET}\n"
-    NEED_AGENT_BROWSER=false
-fi
-
-if echo "$EXISTING_PLUGINS" | grep -q "git@codemate"; then
-    printf "  ${GREEN}✓ git@codemate already installed${RESET}\n"
-    NEED_GIT=false
-fi
-
-if echo "$EXISTING_PLUGINS" | grep -q "pr@codemate"; then
-    printf "  ${GREEN}✓ pr@codemate already installed${RESET}\n"
-    NEED_PR=false
-fi
-
-# Exit early if all plugins are installed
-if [ "$NEED_AGENT_BROWSER" = false ] && [ "$NEED_GIT" = false ] && [ "$NEED_PR" = false ]; then
-    printf "\n${GREEN}✓ All plugins already installed${RESET}\n"
-    exit 0
-fi
-
-printf "\n${YELLOW}Installing missing plugins...${RESET}\n\n"
-
-# Add marketplaces only if needed
-if [ "$NEED_AGENT_BROWSER" = true ]; then
-    printf "${CYAN}Adding agent-browser marketplace:${RESET}\n"
-    add_marketplace "1/1" "vercel-labs/agent-browser" "vercel-labs/agent-browser"
-fi
-
-if [ "$NEED_GIT" = true ] || [ "$NEED_PR" = true ]; then
-    printf "${CYAN}Adding codemate marketplace:${RESET}\n"
-    add_marketplace "1/1" "codemate" "BoringHappy/CodeMate"
-fi
-
-# Install only missing plugins
-printf "\n${CYAN}Installing missing plugins:${RESET}\n"
-INSTALL_COUNT=0
-INSTALL_TOTAL=0
-
-# Count how many plugins need to be installed
-[ "$NEED_AGENT_BROWSER" = true ] && INSTALL_TOTAL=$((INSTALL_TOTAL + 1))
-[ "$NEED_GIT" = true ] && INSTALL_TOTAL=$((INSTALL_TOTAL + 1))
-[ "$NEED_PR" = true ] && INSTALL_TOTAL=$((INSTALL_TOTAL + 1))
-
-if [ "$NEED_AGENT_BROWSER" = true ]; then
-    INSTALL_COUNT=$((INSTALL_COUNT + 1))
-    install_and_verify_plugin "${INSTALL_COUNT}/${INSTALL_TOTAL}" "agent-browser@agent-browser" "/agent-browser:agent-browser"
-fi
-
-if [ "$NEED_GIT" = true ]; then
-    INSTALL_COUNT=$((INSTALL_COUNT + 1))
-    install_and_verify_plugin "${INSTALL_COUNT}/${INSTALL_TOTAL}" "git@codemate" "/git:commit"
-fi
-
-if [ "$NEED_PR" = true ]; then
-    INSTALL_COUNT=$((INSTALL_COUNT + 1))
-    install_and_verify_plugin "${INSTALL_COUNT}/${INSTALL_TOTAL}" "pr@codemate" "/pr:get-details, /pr:fix-comments, /pr:update"
-fi
+# Install plugins (functions check if already installed)
+printf "\n${CYAN}Installing plugins:${RESET}\n"
+install_and_verify_plugin "1/3" "agent-browser@agent-browser" "/agent-browser:agent-browser"
+install_and_verify_plugin "2/3" "git@codemate" "/git:commit"
+install_and_verify_plugin "3/3" "pr@codemate" "/pr:get-details, /pr:fix-comments, /pr:update"
 
 printf "\n${GREEN}✓ Plugin setup complete${RESET}\n"


### PR DESCRIPTION
## Summary

Fix setup-plugins.sh to properly handle cases where only some plugins are installed. Previously, the script would fail or reinstall everything when only part of the plugins were installed.

## Changes

- Update `add_marketplace` function in `common.sh` to check if marketplace is already added before attempting to add it
- Update `install_and_verify_plugin` function in `common.sh` to check if plugin is already installed before attempting installation
- Simplify `setup-plugins.sh` by moving existence checks into the helper functions
- Remove redundant plugin checking logic from the main script

## Testing

- [x] Tests pass locally
- [x] Manual testing completed

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented if unavoidable)