### PR TITLE
Skip Slack notification when no new commits in session

### DIFF
--- a/plugins/pr/hooks/hooks.json
+++ b/plugins/pr/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo \"$(date -u '+%Y-%m-%d %H:%M:%S'), SessionStart\" >> $HOME/.session_status && git rev-parse HEAD 2>/dev/null > $HOME/.session_start_commit"
+            "command": "echo \"$(date -u '+%Y-%m-%d %H:%M:%S'), SessionStart\" >> $HOME/.session_status && git rev-parse HEAD 2>/dev/null > $HOME/.session_commit"
           }
         ]
       }

--- a/plugins/pr/hooks/send_to_slack.sh
+++ b/plugins/pr/hooks/send_to_slack.sh
@@ -6,11 +6,11 @@
 [ -z "$SLACK_WEBHOOK" ] && exit 0
 
 # Check if there are new commits since session start
-START_COMMIT_FILE="$HOME/.session_start_commit"
-if [ -f "$START_COMMIT_FILE" ]; then
-    START_COMMIT=$(cat "$START_COMMIT_FILE")
+COMMIT_FILE="$HOME/.session_commit"
+if [ -f "$COMMIT_FILE" ]; then
+    LAST_NOTIFIED_COMMIT=$(cat "$COMMIT_FILE")
     CURRENT_COMMIT=$(git rev-parse HEAD 2>/dev/null)
-    if [ "$START_COMMIT" = "$CURRENT_COMMIT" ]; then
+    if [ "$LAST_NOTIFIED_COMMIT" = "$CURRENT_COMMIT" ]; then
         # No new commits, skip sending notification
         exit 0
     fi
@@ -46,5 +46,8 @@ PAYLOAD=$(jq -n --arg text "$MESSAGE" '{text: $text}')
 curl -s -X POST -H 'Content-type: application/json' \
     --data "$PAYLOAD" \
     "$SLACK_WEBHOOK" > /dev/null 2>&1
+
+# Update commit file with current commit to avoid duplicate notifications
+git rev-parse HEAD 2>/dev/null > "$COMMIT_FILE"
 
 exit 0


### PR DESCRIPTION
## Summary

Skip Slack notifications when no new commits have been made during a Claude Code session. This prevents unnecessary notifications when a session ends without any code changes.

## Changes

- Record commit hash at session start in `$HOME/.session_commit`
- Compare current commit with recorded commit before sending Slack notification
- Skip notification if commits match (no new work)
- Update commit file after successful notification to prevent duplicates on subsequent stops

## Testing

- [x] Manual testing completed
  - Session with commits → notification sent
  - Session without commits → no notification
  - Multiple stops in same session → only first sends notification

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented if unavoidable)