### PR TITLE
Fix monitor-pr.sh to derive repo directory from GIT_REPO_URL

### DIFF
--- a/setup/shell/monitor-pr.sh
+++ b/setup/shell/monitor-pr.sh
@@ -15,8 +15,12 @@ flock -n 200 || { echo "$(date): Already running, skipping"; exit 0; }
 CLAUDE_SESSION="${CLAUDE_SESSION:-claude-code}"
 STATE_FILE="${STATE_FILE:-/tmp/pr-monitor-state}"
 
-# Ensure we're in the repo directory
-cd "${REPO_DIR:-/home/agent/repo}" 2>/dev/null || cd /home/agent/repo
+# Derive repo directory from GIT_REPO_URL (e.g., https://github.com/org/repo.git -> /home/agent/repo)
+if [ -z "$REPO_DIR" ] && [ -n "$GIT_REPO_URL" ]; then
+    REPO_NAME=$(basename "$GIT_REPO_URL" .git)
+    REPO_DIR="/home/agent/$REPO_NAME"
+fi
+cd "${REPO_DIR:-/home/agent/repo}" || { echo "$(date): Failed to cd to repo directory"; exit 1; }
 
 # Function to check if a tmux session exists
 session_exists() {


### PR DESCRIPTION
## Summary

Fix the PR monitor script to dynamically derive the repository directory from the `GIT_REPO_URL` environment variable instead of using a hardcoded path that does not exist.

## Changes

- Replace hardcoded `/home/user/repo` path with dynamic derivation from `GIT_REPO_URL`
- Extract repo name using `basename "$GIT_REPO_URL" .git`
- Construct repo path as `/home/agent/$REPO_NAME`
- Add proper error handling when `cd` fails
- Maintain backward compatibility with `REPO_DIR` environment variable (takes precedence if set)

## Testing

- [x] Tested with `GIT_REPO_URL=https://github.com/BoringHappy/CodeMate.git` - correctly derives `/home/agent/CodeMate`
- [x] Tested with `REPO_DIR` already set - correctly uses existing value and skips derivation
- [x] Manual testing completed

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented if unavoidable)