### PR TITLE
Optimize Docker base image apt downloads

### DIFF
--- a/.github/workflows/docker-build-base.yml
+++ b/.github/workflows/docker-build-base.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - optimize-docker-image-build-apt  # TODO: Remove after testing
     paths:
       - 'Dockerfile.base'
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Optimize apt package downloads in the Docker base image build by using faster mirrors and reducing unnecessary repository metadata downloads.

## Changes

- Switch apt mirror from default `ports.ubuntu.com` to AWS EC2 mirror (`us-east-1.ec2.ports.ubuntu.com`) for faster downloads
- Disable `multiverse` repository (not needed by any installed packages)
- Remove `backports` repository sources (not used)
- Add temporary workflow trigger for testing on this branch (to be removed before merge)

## Testing

- [x] Manual testing completed
- [ ] Tests pass locally

## Checklist

- [x] Code follows project conventions
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or documented if unavoidable)
