### PR TITLE
Add quick start video to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ CodeMate solves this by running Claude Code in an isolated Docker container wher
 
 ## Quick Start
 
+https://github.com/user-attachments/assets/bb0c68ef-da05-401a-adb3-ea8ccc22667c
+
 ### Prerequisites
 
 - Docker

--- a/README_CN.md
+++ b/README_CN.md
@@ -24,6 +24,8 @@ CodeMate 通过在隔离的 Docker 容器中运行 Claude Code 来解决这个�
 
 ## 快速开始
 
+https://github.com/user-attachments/assets/bb0c68ef-da05-401a-adb3-ea8ccc22667c
+
 ### 前置要求
 
 - Docker


### PR DESCRIPTION
## Summary

Add a quick start video demonstration to both English and Chinese README files to help users quickly understand how to use CodeMate.

## Changes

- Add video link to README.md Quick Start section
- Add video link to README_CN.md Quick Start section (快速开始)

## Testing

- [x] Video link displays correctly in GitHub markdown
- [x] Changes applied to both language versions

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented if unavoidable)