### PR TITLE
Add Related Issues section to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,10 @@
 
 <!-- Briefly describe what this PR does -->
 
+## Related Issues
+
+<!-- Link related issues using #issue_number or "Closes #issue_number" to auto-close -->
+
 ## Changes
 
 <!-- List the key changes made -->


### PR DESCRIPTION
## Summary

Adds a "Related Issues" section to the pull request template, allowing PR authors to easily link related GitHub issues and automatically close them when the PR is merged.

## Related Issues

Closes #119

## Changes

- Added new "Related Issues" section to `.github/PULL_REQUEST_TEMPLATE.md`
- Positioned between Summary and Changes sections for logical flow
- Included helpful comment guidance for linking issues using `#issue_number` or `Closes #issue_number`

## Testing

- [x] Template file updated successfully
- [x] Changes follow existing template format and style
- [x] Comment guidance is clear and actionable

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented if unavoidable)