### PR TITLE
Fix shell syntax error in cleanup job

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -177,7 +177,7 @@ jobs:
     steps:
       - name: Set lowercase image name
         id: image
-        run: echo "name=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')\" >> $GITHUB_OUTPUT
+        run: echo "name=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
 
       - name: Delete untagged images
         uses: actions/delete-package-versions@v5


### PR DESCRIPTION
## Summary

Fixes a shell syntax error in the Docker build workflow's cleanup job that was causing the GitHub Actions workflow to fail with "unexpected EOF while looking for matching quote" error.

## Related Issues

Related to #125 (cleanup job implementation)

## Changes

- Fixed escaped quote syntax error in `.github/workflows/docker-build-push.yml:180`
- Changed `\"` to `"` in the cleanup job's "Set lowercase image name" step

## Testing

- [x] Syntax error identified and corrected
- [ ] Workflow will be tested on merge to verify cleanup job runs successfully

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented if unavoidable)