### PR TITLE
Update installation path from ~/bin to ~/.local/bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Install `codemate` globally to use it from anywhere:
 # Install directly to /usr/local/bin (requires sudo)
 sudo curl -fsSL https://raw.githubusercontent.com/BoringHappy/CodeMate/main/codemate -o /usr/local/bin/codemate && sudo chmod +x /usr/local/bin/codemate
 
-# Or install to ~/bin without sudo (ensure ~/bin is in your PATH)
-mkdir -p ~/bin && curl -fsSL https://raw.githubusercontent.com/BoringHappy/CodeMate/main/codemate -o ~/bin/codemate && chmod +x ~/bin/codemate
+# Or install to ~/.local/bin without sudo (ensure ~/.local/bin is in your PATH)
+curl -fsSL https://raw.githubusercontent.com/BoringHappy/CodeMate/main/codemate -o ~/.local/bin/codemate && chmod +x ~/.local/bin/codemate
 
 # One-time global setup
 codemate --setup


### PR DESCRIPTION
## Summary

Updates the user-level installation instructions to use `~/.local/bin` instead of `~/bin`, following the XDG Base Directory specification which is the modern standard for user-installed executables on Linux systems.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Infrastructure/tooling change
- [ ] Plugin update

## Changes

- Updated installation path from `~/bin` to `~/.local/bin` in README.md
- Removed `mkdir -p` command from installation instructions (simplified the command)
- `~/.local/bin` is included in PATH by default on most modern Linux distributions

## Testing

- [x] Tested locally
- [ ] Docker build/container works (if applicable)
- [x] Manual testing completed

## Checklist

- [x] Code follows project conventions (shell script style, Python formatting)
- [x] Documentation updated (README.md, CLAUDE.md, or relevant docs)
- [x] No breaking changes (or clearly documented with migration guide if unavoidable)
- [ ] GitHub Actions workflows pass (if modified)
- [x] Commit messages are clear and follow conventional commit style