### PR TITLE
Update legacy start.sh references to codemate

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,12 +285,12 @@ CodeMate supports starting work directly from a GitHub issue using the `--issue`
 
 ```bash
 # Start working on issue #456
-./start.sh --issue 456
+codemate --issue 456
 ```
 
 This is equivalent to:
 ```bash
-./start.sh --branch issue-456 --query "Please use /pr:read-issue skill to read and address issue #456"
+codemate --branch issue-456 --query "Please use /pr:read-issue skill to read and address issue #456"
 ```
 
 **When to use:**

--- a/codemate
+++ b/codemate
@@ -114,7 +114,7 @@ EOF
     print_success "Created $settings_file"
 }
 
-# Function to update start.sh script
+# Function to update codemate script
 update_script() {
     local script_path="$0"
     local temp_file="/tmp/codemate.tmp"
@@ -711,7 +711,7 @@ main() {
         print_error "GIT_REPO_URL not set"
         echo ""
         echo "The repository URL can be provided in three ways (in priority order):"
-        echo "  1. Use --repo option: ./start.sh --repo https://github.com/user/repo.git --branch xyz"
+        echo "  1. Use --repo option: codemate --repo https://github.com/user/repo.git --branch xyz"
         echo "  2. Set GIT_REPO_URL in .env file"
         echo "  3. Run from a git repository directory (auto-detects remote origin)"
         echo ""


### PR DESCRIPTION
## Summary

This PR completes the migration from `start.sh` to `codemate` by updating all remaining references in documentation and code comments. Following PR #136 which renamed the script itself, this ensures consistency across the entire codebase.

## Related Issues

Follows up on #136 (Rename start.sh to codemate with global installation support)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Infrastructure/tooling change
- [ ] Plugin update

## Changes

- **README.md**: Updated example commands in the "Working with GitHub Issues" section
  - Changed `./start.sh --issue 456` to `codemate --issue 456`
  - Changed `./start.sh --branch issue-456 ...` to `codemate --branch issue-456 ...`
- **codemate**: Updated internal references
  - Changed function comment from "update start.sh script" to "update codemate script"
  - Updated error message example from `./start.sh --repo ...` to `codemate --repo ...`

## Testing

- [x] Tested locally
- [ ] Docker build/container works (if applicable)
- [x] Manual testing completed

Verified all references to `start.sh` have been removed from the codebase using grep.

## Checklist

- [x] Code follows project conventions (shell script style, Python formatting)
- [x] Documentation updated (README.md, CLAUDE.md, or relevant docs)
- [x] No breaking changes (or clearly documented with migration guide if unavoidable)
- [ ] GitHub Actions workflows pass (if modified)
- [x] Commit messages are clear and follow conventional commit style