### PR TITLE
Add dev plugin to default plugins installation

### DIFF
--- a/setup/shell/setup-plugins.sh
+++ b/setup/shell/setup-plugins.sh
@@ -42,9 +42,10 @@ fi
 
 # Install default plugins (functions check if already installed)
 printf "\n${CYAN}Installing default plugins:${RESET}\n"
-install_and_verify_plugin "1/3" "agent-browser@agent-browser" "/agent-browser:agent-browser"
-install_and_verify_plugin "2/3" "git@codemate" "/git:commit"
-install_and_verify_plugin "3/3" "pr@codemate" "/pr:get-details, /pr:fix-comments, /pr:update"
+install_and_verify_plugin "1/4" "agent-browser@agent-browser" "/agent-browser:agent-browser"
+install_and_verify_plugin "2/4" "git@codemate" "/git:commit"
+install_and_verify_plugin "3/4" "pr@codemate" "/pr:get-details, /pr:fix-comments, /pr:update"
+install_and_verify_plugin "4/4" "dev@codemate" "/dev:read-env-key"
 
 # Install custom plugins from environment variable
 if [ -n "$CUSTOM_PLUGINS" ]; then


### PR DESCRIPTION
## Summary

Add the `dev` plugin to the default plugins installation list in `setup-plugins.sh`. This ensures the dev plugin (which provides the `/dev:read-env-key` skill for safely inspecting environment variable keys) is automatically installed during container startup alongside other default plugins.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Infrastructure/tooling change
- [x] Plugin update

## Changes

- Add `dev@codemate` plugin to default plugins installation list in `setup/shell/setup-plugins.sh`
- Update plugin count from 3 to 4 in installation progress indicators
- Plugin provides `/dev:read-env-key` skill for listing environment variable keys without exposing values

## Testing

- [x] Tested locally
- [ ] Docker build/container works (if applicable)
- [ ] Manual testing completed

## Checklist

- [x] Code follows project conventions (shell script style, Python formatting)
- [ ] Documentation updated (README.md, CLAUDE.md, or relevant docs)
- [x] No breaking changes (or clearly documented with migration guide if unavoidable)
- [ ] GitHub Actions workflows pass (if modified)
- [x] Commit messages are clear and follow conventional commit style