### PR TITLE
Add marketplace update step to plugin setup

### DIFF
--- a/setup/shell/common.sh
+++ b/setup/shell/common.sh
@@ -51,6 +51,19 @@ add_marketplace() {
     fi
 }
 
+# Function to update all Claude plugin marketplaces
+# Usage: update_marketplaces
+update_marketplaces() {
+    printf "  Updating marketplaces to fetch latest plugin information...\\n"
+    if claude plugin marketplace update 2>&1; then
+        printf "  ${GREEN}✓ Marketplaces updated successfully${RESET}\\n"
+        return 0
+    else
+        printf "  ${YELLOW}⚠ Failed to update marketplaces${RESET}\\n"
+        return 1
+    fi
+}
+
 # Function to install and verify a Claude plugin (checks if already installed)
 # Usage: install_and_verify_plugin "index/total" "plugin-name" "skill1, skill2, skill3"
 install_and_verify_plugin() {

--- a/setup/shell/setup-plugins.sh
+++ b/setup/shell/setup-plugins.sh
@@ -40,6 +40,10 @@ if [ -n "$CUSTOM_MARKETPLACES" ]; then
     done
 fi
 
+# Update marketplaces to fetch latest plugin information
+printf "\n${CYAN}Updating marketplaces:${RESET}\n"
+update_marketplaces
+
 # Install default plugins (functions check if already installed)
 printf "\n${CYAN}Installing default plugins:${RESET}\n"
 install_and_verify_plugin "1/4" "agent-browser@agent-browser" "/agent-browser:agent-browser"


### PR DESCRIPTION
## Summary

Adds a marketplace update step to the plugin setup process to ensure plugins are installed with the latest metadata. After adding all marketplaces (both default and custom), the setup now updates them to fetch the most current plugin information before proceeding with plugin installation.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Infrastructure/tooling change
- [ ] Plugin update

## Changes

- Added `update_marketplaces()` function to `setup/shell/common.sh` that runs `claude plugin marketplace update`
- Updated `setup/shell/setup-plugins.sh` to call marketplace update after adding all marketplaces but before installing plugins
- Ensures plugin installation uses up-to-date marketplace metadata

## Testing

- [x] Tested locally
- [x] Docker build/container works (if applicable)
- [ ] Manual testing completed

## Checklist

- [x] Code follows project conventions (shell script style, Python formatting)
- [ ] Documentation updated (README.md, CLAUDE.md, or relevant docs)
- [x] No breaking changes (or clearly documented with migration guide if unavoidable)
- [ ] GitHub Actions workflows pass (if modified)
- [x] Commit messages are clear and follow conventional commit style