### PR TITLE
Fix container name collision by including repo name

### DIFF
--- a/codemate
+++ b/codemate
@@ -350,12 +350,14 @@ run_codemate() {
         exit 1
     fi
 
-    # Determine container name
-    local branch_for_name="${BRANCH_NAME:-main}"
-    CONTAINER_NAME="codemate-$(echo "$branch_for_name" | sed 's/[^a-zA-Z0-9_-]/-/g')"
-
     # Extract repo name from git URL
     REPO_NAME=$(echo "$GIT_REPO_URL" | sed 's/\.git$//' | sed 's|.*/||')
+
+    # Determine container name (include repo name to avoid conflicts between repos with same branch)
+    local branch_for_name="${BRANCH_NAME:-main}"
+    local repo_for_name=$(echo "$REPO_NAME" | sed 's/[^a-zA-Z0-9_-]/-/g')
+    local branch_sanitized=$(echo "$branch_for_name" | sed 's/[^a-zA-Z0-9_-]/-/g')
+    CONTAINER_NAME="codemate-${repo_for_name}-${branch_sanitized}"
 
     # Detect OS for network flag
     NETWORK_FLAG=""


### PR DESCRIPTION
## Summary

Fixed a bug where Docker container names were generated using only the branch name, causing conflicts when working with multiple repositories that have the same branch name. Container names now include both the repository name and branch name to ensure uniqueness.

## Related Issues

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Infrastructure/tooling change
- [ ] Plugin update

## Changes

- Modified `codemate` script to include repository name in Docker container naming
- Reordered logic to extract repo name before generating container name
- Added sanitization for repo name to ensure valid Docker container names
- Container name pattern changed from `codemate-{branch}` to `codemate-{repo}-{branch}`

**Example:**
- Before: `codemate-feature-xyz` (conflicts if multiple repos have same branch)
- After: `codemate-repo-a-feature-xyz` and `codemate-repo-b-feature-xyz` (unique per repo)

## Testing

- [x] Tested locally
- [x] Docker build/container works (if applicable)
- [x] Manual testing completed

## Checklist

- [x] Code follows project conventions (shell script style, Python formatting)
- [ ] Documentation updated (README.md, CLAUDE.md, or relevant docs)
- [x] No breaking changes (or clearly documented with migration guide if unavoidable)
- [ ] GitHub Actions workflows pass (if modified)
- [x] Commit messages are clear and follow conventional commit style