### PR TITLE
Add comment context when sending /fix-comments command

### DIFF
--- a/setup/shell/monitor-pr.sh
+++ b/setup/shell/monitor-pr.sh
@@ -102,17 +102,10 @@ check_pr_comments() {
             . $time_filter |
             group_by(.in_reply_to_id // .id) |
             map(
-                if (
-                    (.[0].body | startswith(\"Claude Replied:\")) or
-                    (.[-1].body | startswith(\"Claude Replied:\"))
-                ) then
+                if (.[-1].body | startswith(\"Claude Replied:\")) then
                     empty
                 else
-                    if .[0].in_reply_to_id == null then
-                        .[0]
-                    else
-                        empty
-                    end
+                    .[-1]
                 end
             )
         " 2>/dev/null)


### PR DESCRIPTION
## Summary

Optimized the PR monitor script to include actual PR review comment content when notifying Claude to use the `/fix-comments` skill. This provides immediate context without requiring an additional API call, improving efficiency and user experience.

## Related Issues

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Infrastructure/tooling change
- [ ] Plugin update

## Changes

### 1. Enhanced comment context delivery (Commit: f770d0a)
- Modified `check_pr_comments()` function to return full comment objects instead of just count
- Added comment formatting logic to extract file path, line number, author, and comment body
- Updated the message sent to Claude to include formatted comment details

**Before:**
```bash
send_and_verify_command "$CLAUDE_SESSION" "Please Use /fix-comments skill to address comments" 3
```

**After:**
```bash
comment_summary=$(echo "$comments_data" | jq -r '
    map(
        "- \(.path):\(.line // .original_line) by @\(.user.login):\n  \(.body | split("\n") | join("\n  "))"
    ) | join("\n\n")
')
send_and_verify_command "$CLAUDE_SESSION" "Please use /fix-comments skill to address the following PR review comments:

$comment_summary" 3
```

### 2. Fixed comment filtering logic (Commit: 3a7ab0e)
- Simplified jq query to check only if the last comment in a thread starts with "Claude Replied:"
- Fixed issue where human replies to Claude's responses were incorrectly filtered out
- Changed from returning only top-level comments to returning the last comment in each unresolved thread

**Before:** Only kept comments with `in_reply_to_id == null` (top-level only)
**After:** Returns last comment in thread if it doesn't start with "Claude Replied:" (includes follow-up replies)

## Testing

- [x] Tested locally
- [ ] Docker build/container works (if applicable)
- [ ] Manual testing completed

## Checklist

- [x] Code follows project conventions (shell script style, Python formatting)
- [ ] Documentation updated (README.md, CLAUDE.md, or relevant docs)
- [x] No breaking changes (or clearly documented with migration guide if unavoidable)
- [ ] GitHub Actions workflows pass (if modified)
- [x] Commit messages are clear and follow conventional commit style