### PR TITLE
Use GitHub API for adding pr-updated label

### DIFF
--- a/setup/shell/monitor-pr.sh
+++ b/setup/shell/monitor-pr.sh
@@ -225,7 +225,7 @@ check_pr_ready_for_review() {
     # PR is ready for review and doesn't have the label
     echo "$(date): PR is ready for review, notifying Claude"
     if session_exists "$CLAUDE_SESSION"; then
-        send_and_verify_command "$CLAUDE_SESSION" "The PR is now ready for review. Please use /pr:update skill to update the PR title and description based on all changes made. After updating, add the 'pr-updated' label to the GitHub PR using: gh pr edit --add-label pr-updated" 3
+        send_and_verify_command "$CLAUDE_SESSION" "The PR is now ready for review. Please use /pr:update skill to update the PR title and description based on all changes made. After updating, add the 'pr-updated' label to the GitHub PR using: gh api repos/:owner/:repo/issues/$pr_number/labels --input - <<< '[\"pr-updated\"]'" 3
         READY_FOR_REVIEW_NOTIFIED="true"
         return 1  # Signal that we sent a notification
     fi


### PR DESCRIPTION
## Summary

Updates the PR monitoring script to use the GitHub API directly for adding labels instead of the `gh pr edit` command. This change improves reliability and provides more explicit control over label management.

### Changes

- Modified `setup/shell/monitor-pr.sh` to use `gh api repos/:owner/:repo/issues/$pr_number/labels` instead of `gh pr edit --add-label` when adding the 'pr-updated' label
- The new command uses the GitHub REST API with proper JSON input format for label addition

## Related Issues

N/A

## Testing

- [ ] Tested locally
- [ ] Docker build/container works (if applicable)
- [ ] Manual testing completed

## Checklist

- [x] Code follows project conventions (shell script style, Python formatting)
- [ ] Documentation updated (README.md, CLAUDE.md, or relevant docs)
- [x] No breaking changes (or clearly documented with migration guide if unavoidable)
- [ ] GitHub Actions workflows pass (if modified)
- [x] Commit messages are clear and follow conventional commit style