### PR TITLE
Add automated Docker build on Claude Code releases

### DIFF
--- a/.github/workflows/monitor-claude-releases.yml
+++ b/.github/workflows/monitor-claude-releases.yml
@@ -1,0 +1,63 @@
+name: Monitor Claude Code Releases
+
+on:
+  schedule:
+    # Run every 6 hours
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+jobs:
+  check-release:
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+
+    steps:
+      - name: Check latest Claude Code release
+        id: check
+        run: |
+          # Fetch package info from npm registry
+          PACKAGE_INFO=$(curl -s https://registry.npmjs.org/@anthropic-ai/claude-code)
+
+          # Get latest version and its publish time
+          LATEST_VERSION=$(echo "$PACKAGE_INFO" | jq -r '.["dist-tags"].latest')
+          PUBLISH_TIME=$(echo "$PACKAGE_INFO" | jq -r ".time[\"$LATEST_VERSION\"]")
+
+          if [ -z "$LATEST_VERSION" ] || [ "$LATEST_VERSION" = "null" ]; then
+            echo "Error: Could not fetch latest version"
+            exit 1
+          fi
+
+          echo "Latest version: $LATEST_VERSION"
+          echo "Published at: $PUBLISH_TIME"
+
+          # Calculate time difference in seconds
+          PUBLISH_TIMESTAMP=$(date -d "$PUBLISH_TIME" +%s)
+          CURRENT_TIMESTAMP=$(date +%s)
+          TIME_DIFF=$((CURRENT_TIMESTAMP - PUBLISH_TIMESTAMP))
+          HOURS_DIFF=$((TIME_DIFF / 3600))
+
+          echo "Hours since release: $HOURS_DIFF"
+
+          # Check if released in last 24 hours
+          if [ $HOURS_DIFF -lt 24 ]; then
+            echo "new_release=true" >> $GITHUB_OUTPUT
+            echo "version=$LATEST_VERSION" >> $GITHUB_OUTPUT
+            echo "✓ New release detected within last 24 hours!"
+          else
+            echo "new_release=false" >> $GITHUB_OUTPUT
+            echo "No new release in the last 24 hours"
+          fi
+
+      - name: Trigger Docker build
+        if: steps.check.outputs.new_release == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'docker-build-push.yml',
+              ref: 'main'
+            });
+            console.log('Triggered docker-build-push workflow for Claude Code version ${{ steps.check.outputs.version }}');


### PR DESCRIPTION
## Summary

Adds automated monitoring of Claude Code releases to trigger Docker image rebuilds when new versions are published. The workflow checks the npm registry every 6 hours and automatically triggers the build pipeline when a new Claude Code version is released within the last 24 hours.

### Changes

- Added `.github/workflows/monitor-claude-releases.yml` workflow that:
  - Runs on a schedule every 6 hours (configurable via cron)
  - Fetches latest Claude Code version from npm registry (`@anthropic-ai/claude-code`)
  - Checks the publish timestamp of the latest version
  - Triggers `docker-build-push.yml` workflow if version was released in last 24 hours
  - Uses stateless approach (no version tracking file needed)

### Implementation Details

- Queries npm registry for `@anthropic-ai/claude-code` package metadata
- Calculates time difference between current time and package publish time
- Triggers build only if release is within 24-hour window
- Includes error handling for network failures and invalid responses
- Tested with multiple scenarios: recent releases, old releases, and error conditions

## Related Issues

Implements automatic Docker image updates when Claude Code releases new versions, ensuring CodeMate stays current with the latest Claude Code features and fixes.

## Testing

- [x] Tested locally (logic verified with npm registry queries)
- [ ] Docker build/container works (if applicable)
- [x] Manual testing completed (workflow syntax validated)
- [x] Workflow logic tested with multiple scenarios

## Checklist

- [x] Code follows project conventions (shell script style, Python formatting)
- [ ] Documentation updated (README.md, CLAUDE.md, or relevant docs)
- [x] No breaking changes (or clearly documented with migration guide if unavoidable)
- [x] GitHub Actions workflows pass (if modified)
- [x] Commit messages are clear and follow conventional commit style