### PR TITLE
Fix read-issue skill: use ARGUMENTS instead of ISSUE_NUMBER

### DIFF
--- a/codemate
+++ b/codemate
@@ -695,7 +695,7 @@ main() {
 
             # Set initial query if not already set
             if [ -z "$QUERY" ]; then
-                QUERY="Please use /issue:read-issue skill to read and address issue #${ISSUE_NUMBER} (${ISSUE_URL})"
+                QUERY="Please use \`/issue:read-issue ${ISSUE_NUMBER}\` skill to read and address issue #${ISSUE_NUMBER} (${ISSUE_URL})"
             fi
         fi
 

--- a/plugins/issue/skills/read-issue/SKILL.md
+++ b/plugins/issue/skills/read-issue/SKILL.md
@@ -9,13 +9,13 @@ Retrieves and displays GitHub issue information including title, description, la
 
 ## Issue Information
 
-!`gh issue view ${ARGUMENTS:-$ISSUE_NUMBER} --json title,state,labels,assignees,body,url,comments --template '{{.title}}{{"\n"}}{{.state}}{{"\n"}}{{.url}}{{"\n"}}Labels: {{range .labels}}{{.name}} {{end}}{{"\n"}}Assignees: {{range .assignees}}{{.login}} {{end}}{{"\n"}}{{.body}}{{"\n"}}{{range .comments}}{{.author.login}} - {{.createdAt}}:{{"\n"}}{{.body}}{{"\n\n"}}{{end}}' | cat`
+!`gh issue view $ARGUMENTS --json title,state,labels,assignees,body,url,comments --template '{{.title}}{{"\n"}}{{.state}}{{"\n"}}{{.url}}{{"\n"}}Labels: {{range .labels}}{{.name}} {{end}}{{"\n"}}Assignees: {{range .assignees}}{{.login}} {{end}}{{"\n"}}{{.body}}{{"\n"}}{{range .comments}}{{.author.login}} - {{.createdAt}}:{{"\n"}}{{.body}}{{"\n\n"}}{{end}}' | cat`
 
 ## Instructions
 
 **IMPORTANT: You MUST output a summary to the user.** After gathering the issue information above, display a formatted summary that includes:
 
-1. **Issue Number** - The issue number (from `$ARGUMENTS` or `$ISSUE_NUMBER`)
+1. **Issue Number** - The issue number (from `$ARGUMENTS`)
 2. **Title** - The issue title
 3. **State** - Whether the issue is open or closed
 4. **Labels** - Any labels attached to the issue (or "None" if empty)


### PR DESCRIPTION
## Summary

Replace the deprecated `$ISSUE_NUMBER` fallback in the `read-issue` skill with `$ARGUMENTS`, and update the auto-generated issue query in the `codemate` script to use backtick-formatted skill invocation.

### Changes

- `plugins/issue/skills/read-issue/SKILL.md`: Changed `${ARGUMENTS:-$ISSUE_NUMBER}` to `$ARGUMENTS` in the `gh issue view` command; updated instructions to reference only `$ARGUMENTS`
- `codemate`: Updated the auto-generated `QUERY` for issue-based workflows to use `` `/issue:read-issue ${ISSUE_NUMBER}` `` with backtick formatting for clarity

## Related Issues

<!-- Link related issues using #issue_number or "Closes #issue_number" to auto-close -->

## Testing

- [ ] Tested locally
- [ ] Docker build/container works (if applicable)
- [x] Manual testing completed

## Checklist

- [x] Code follows project conventions (shell script style, Python formatting)
- [ ] Documentation updated (README.md, CLAUDE.md, or relevant docs)
- [x] No breaking changes (or clearly documented with migration guide if unavoidable)
- [ ] GitHub Actions workflows pass (if modified)
- [x] Commit messages are clear and follow conventional commit style