### PR TITLE
Fix read-issue skill: remove planning instruction

### DIFF
--- a/plugins/issue/skills/read-issue/SKILL.md
+++ b/plugins/issue/skills/read-issue/SKILL.md
@@ -25,5 +25,3 @@ Retrieves and displays GitHub issue information including title, description, la
 8. **Issue URL** - Direct link to the issue
 
 Format the output clearly using markdown so the user can see the issue details at a glance. This summary should always be visible in your response to the user.
-
-After displaying the issue information, you should analyze the requirements and start planning how to address the issue.


### PR DESCRIPTION
## Summary

Removes the instruction that told Claude to analyze requirements and start planning after displaying issue information. This keeps the read-issue skill focused on its single responsibility: displaying issue details.

### Changes

- `plugins/issue/skills/read-issue/SKILL.md`: Remove trailing line "After displaying the issue information, you should analyze the requirements and start planning how to address the issue."

## Related Issues

<!-- Link related issues using #issue_number or "Closes #issue_number" to auto-close -->

## Testing

- [ ] Tested locally
- [ ] Docker build/container works (if applicable)
- [x] Manual testing completed

## Checklist

- [x] Code follows project conventions (shell script style, Python formatting)
- [ ] Documentation updated (README.md, CLAUDE.md, or relevant docs)
- [x] No breaking changes (or clearly documented with migration guide if unavoidable)
- [ ] GitHub Actions workflows pass (if modified)
- [x] Commit messages are clear and follow conventional commit style