### PR TITLE
Add --granularity argument to spec-plan skill

### DIFF
--- a/plugins/pm/skills/spec-plan/SKILL.md
+++ b/plugins/pm/skills/spec-plan/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: spec-plan
 description: Converts a SPEC.md into a technical implementation plan by appending architecture decisions, tech approach, and a task breakdown. Use after spec-init to turn requirements into an engineering plan. Accepts an optional --granularity flag (micro | pr | macro) to control task sizing.
+argument-hint: <feature-name> [--granularity micro|pr|macro]
 ---
 
 # Spec Plan
@@ -13,7 +14,7 @@ Usage: `/pm:spec-plan <feature-name> [--granularity micro|pr|macro]`
 
 !`
 FEATURE_NAME=$(echo "$ARGUMENTS" | awk '{print $1}')
-GRANULARITY=$(echo "$ARGUMENTS" | grep -oP '(?<=--granularity )\S+')
+GRANULARITY=$(echo "$ARGUMENTS" | sed -n 's/.*--granularity[[:space:]]\+\([^[:space:]]\+\).*/\1/p')
 GRANULARITY="${GRANULARITY:-pr}"
 SPEC=".claude/specs/$FEATURE_NAME.md"
 
@@ -102,9 +103,9 @@ cat "$SPEC"
 
 5. Update the spec frontmatter `status` from `draft` to `planned`.
 
-6. Confirm: "✅ Technical plan added to `.claude/specs/$FEATURE_NAME.md` (granularity: <value>)"
-7. Suggest next step: "Ready to create tasks? Run: `/pm:spec-decompose $FEATURE_NAME`"
+6. Confirm: "✅ Technical plan added to `.claude/specs/<feature-name>.md` (granularity: <value>)"
+7. Suggest next step: "Ready to create tasks? Run: `/pm:spec-decompose <feature-name>`"
 
 ## Prerequisites
-- Spec must exist at `.claude/specs/$FEATURE_NAME.md`
-- Run `/pm:spec-init $FEATURE_NAME` first if it doesn't
+- Spec must exist at `.claude/specs/<feature-name>.md`
+- Run `/pm:spec-init <feature-name>` first if it doesn't


### PR DESCRIPTION
## Summary

Adds an optional `--granularity` flag to the `spec-plan` skill, giving users control over how coarse or fine the task breakdown should be when generating a technical implementation plan.

### Changes

- `plugins/pm/skills/spec-plan/SKILL.md`: Added `--granularity micro|pr|macro` optional argument with shell parsing, validation, and granularity-aware task sizing instructions in the LLM prompt

**Granularity values:**
| Value | Task size | Max tasks | Use case |
|-------|-----------|-----------|----------|
| `micro` | 0.5–1 day | 10–20 | Fine-grained, commit-level tasks |
| `pr` | 1–3 days | 5–10 | PR-sized shippable units (default, preserves existing behavior) |
| `macro` | 3–7 days | 3–5 | Large milestones / epics |

The default is `pr`, so all existing invocations without the flag behave identically to before. The `Estimate` column and `<!-- granularity: ... -->` comment are now embedded in the task breakdown table for downstream skill consumption.

**Usage:**
```
/pm:spec-plan <feature-name>
/pm:spec-plan <feature-name> --granularity micro
/pm:spec-plan <feature-name> --granularity macro
```

## Related Issues

<!-- Link related issues using #issue_number or "Closes #issue_number" to auto-close -->

## Testing

- [ ] Tested locally
- [ ] Docker build/container works (if applicable)
- [ ] Manual testing completed

## Checklist

- [ ] Code follows project conventions (shell script style, Python formatting)
- [ ] Documentation updated (README.md, CLAUDE.md, or relevant docs)
- [x] No breaking changes (or clearly documented with migration guide if unavoidable)
- [ ] GitHub Actions workflows pass (if modified)
- [x] Commit messages are clear and follow conventional commit style