### PR TITLE
Add spec-next skill and --granularity flag to spec-decompose

### DIFF
--- a/plugins/pm/README.md
+++ b/plugins/pm/README.md
@@ -15,6 +15,7 @@ Spec-driven project management for GitHub repos. Guides a feature from raw requi
 /pm:spec-sync <name>       # tasks → GitHub Issues, issue numbers written back to spec
       ↓
 /pm:spec-status <name>     # live progress summary from spec + GitHub Issues
+/pm:spec-next <name>       # find next actionable task based on dependencies
 ```
 
 ## Skills
@@ -30,14 +31,20 @@ Covers: problem statement, user stories, functional/non-functional requirements,
 ### `/pm:spec-plan <feature-name>`
 Reads the spec and appends a technical implementation plan: architecture decisions, area-by-area approach, and a task breakdown table (max 10 tasks, sized 1–3 days each).
 
-### `/pm:spec-decompose <feature-name>`
-Parses the task breakdown table and writes structured task entries into the spec's `tasks:` frontmatter field. Each task gets: title, tags, dependencies, and empty issue/issue_url fields ready for sync.
+### `/pm:spec-decompose <feature-name> [--granularity micro|pr|macro]`
+Parses the task breakdown table and writes structured task entries into the spec's `tasks:` frontmatter field. The `--granularity` flag controls how tasks are split:
+- `micro` — split aggressively into 0.5–1 day tasks
+- `pr` (default) — PR-sized 1–3 day tasks; auto-detected from spec if set by `spec-plan`
+- `macro` — merge into 3–7 day milestones
 
 ### `/pm:spec-sync <feature-name>`
 Creates a GitHub Issue per task using the repo's issue template and writes the issue number and URL back into the spec frontmatter. Skips already-synced tasks (idempotent). Updates spec `status` to `in-progress`.
 
 ### `/pm:spec-status <feature-name>`
 Reads the spec and fetches live issue state from GitHub for each task. Shows a progress table (✅ closed / 🔄 open / ⚠️ not synced), a progress bar, blocked tasks, and what's next to work on.
+
+### `/pm:spec-next <feature-name>`
+Finds the next actionable task(s) by checking live GitHub Issue status and resolving dependencies. Lists tasks that are open with all dependencies closed, and highlights blocked tasks.
 
 ### `/pm:spec-abandon <feature-name>`
 Marks a spec as abandoned and optionally closes any linked open GitHub Issues. Use when a feature is cancelled or no longer being pursued.

--- a/plugins/pm/skills/spec-decompose/SKILL.md
+++ b/plugins/pm/skills/spec-decompose/SKILL.md
@@ -1,29 +1,50 @@
 ---
 name: spec-decompose
-description: Breaks the task breakdown in a SPEC.md into structured task entries and writes them back into the spec's frontmatter tasks list. Use after spec-plan to prepare tasks before syncing to GitHub.
+description: Breaks the task breakdown in a SPEC.md into structured task entries and writes them back into the spec's frontmatter tasks list. Use after spec-plan to prepare tasks before syncing to GitHub. Accepts an optional --granularity flag (micro | pr | macro) to control task splitting.
+argument-hint: <feature-name> [--granularity micro|pr|macro]
 ---
 
 # Spec Decompose
 
-Reads the Task Breakdown table from `.claude/specs/$ARGUMENTS.md` and writes structured task entries into the spec's `tasks:` frontmatter field.
+Reads the Task Breakdown table from `.claude/specs/<feature-name>.md` and writes structured task entries into the spec's `tasks:` frontmatter field.
+
+Usage: `/pm:spec-decompose <feature-name> [--granularity micro|pr|macro]`
 
 ## Preflight
 
 !`
-SPEC=".claude/specs/$ARGUMENTS.md"
+FEATURE_NAME=$(echo "$ARGUMENTS" | awk '{print $1}')
+GRANULARITY=$(echo "$ARGUMENTS" | sed -n 's/.*--granularity[[:space:]]\+\([^[:space:]]\+\).*/\1/p')
+SPEC=".claude/specs/$FEATURE_NAME.md"
 
-if [ -z "$ARGUMENTS" ]; then
-  echo "[ERROR] No feature name provided. Usage: /pm:spec-decompose <feature-name>"
+if [ -z "$FEATURE_NAME" ]; then
+  echo "[ERROR] No feature name provided. Usage: /pm:spec-decompose <feature-name> [--granularity micro|pr|macro]"
   exit 1
 fi
 
 if [ ! -f "$SPEC" ]; then
-  echo "[ERROR] Spec not found: $SPEC. Run /pm:spec-init $ARGUMENTS first."
+  echo "[ERROR] Spec not found: $SPEC. Run /pm:spec-init $FEATURE_NAME first."
   exit 1
 fi
 
+if [ -n "$GRANULARITY" ]; then
+  case "$GRANULARITY" in
+    micro|pr|macro) ;;
+    *)
+      echo "[ERROR] Invalid granularity: '$GRANULARITY'. Must be one of: micro, pr, macro"
+      exit 1
+      ;;
+  esac
+  echo "[INFO] Granularity override: $GRANULARITY"
+else
+  # Try to detect granularity from the Task Breakdown comment in the spec
+  DETECTED=$(grep -m1 '<!-- granularity:' "$SPEC" 2>/dev/null | sed 's/.*granularity: *\([^ >]*\).*/\1/')
+  GRANULARITY="${DETECTED:-pr}"
+  echo "[INFO] Granularity: $GRANULARITY (${DETECTED:+detected from spec}${DETECTED:-default})"
+fi
+
 if ! grep -q "^## Task Breakdown" "$SPEC" 2>/dev/null; then
-  echo "[ERROR] No Task Breakdown section found. Run /pm:spec-plan $ARGUMENTS first."
+  echo "[ERROR] No Task Breakdown section found. Run /pm:spec-plan $FEATURE_NAME first."
   exit 1
 fi
 
@@ -43,13 +64,17 @@ cat "$SPEC"
 
 1. **If tasks already exist in frontmatter** (detected above), ask: "Tasks already decomposed. Re-decompose? (yes/no)". If yes, clear the existing `tasks:` list before proceeding.
 
-2. **Parse the Task Breakdown table** from the spec. For each row extract:
-   - Task number
+2. **Determine task splitting rules** from the granularity reported in preflight:
+   - `micro` — Split aggressively. Each task: 0.5–1 day. One concern per task (single endpoint, single component, single migration). If a table row covers multiple concerns, split it into multiple tasks.
+   - `pr` (default) — Keep tasks as PR-sized units. Each task: 1–3 days. Merge very small table rows if they naturally belong together; split rows that are clearly too large.
+   - `macro` — Merge related tasks into milestones. Each task: 3–7 days. Group table rows by area (e.g. all data-layer rows → one task). Aim for 3–5 tasks total.
+
+3. **Parse the Task Breakdown table** from the spec. Apply the splitting rules above to produce the final task list. For each resulting task extract:
    - Title
    - Tags
-   - Dependencies (task numbers it depends on)
+   - Dependencies (1-based indices into the final task list after splitting/merging)
 
-3. **Rewrite the `tasks:` frontmatter field** with structured entries. Each task gets:
+4. **Rewrite the `tasks:` frontmatter field** with structured entries:
 
 ```yaml
 tasks:
@@ -66,17 +91,17 @@ tasks:
 ```
 
    Fields:
-   - `title`: task title from the breakdown table
+   - `title`: task title
    - `tags`: list of labels e.g. [data], [api], [ui], [infra], or multiple like [api, auth]
-   - `depends_on`: list of task numbers (1-based, matching table order)
+   - `depends_on`: list of task numbers (1-based, matching final task list order)
    - `issue`: GitHub issue number — empty until synced
    - `issue_url`: GitHub issue URL — empty until synced
 
-4. Update the spec frontmatter `status` to `ready`.
+5. Update the spec frontmatter `status` to `ready`.
 
-5. Confirm: "✅ Decomposed <n> tasks into `.claude/specs/$ARGUMENTS.md`"
-6. Suggest next step: "Ready to push to GitHub? Run: `/pm:spec-sync $ARGUMENTS`"
+6. Confirm: "✅ Decomposed <n> tasks into `.claude/specs/$FEATURE_NAME.md` (granularity: <value>)"
+7. Suggest next step: "Ready to push to GitHub? Run: `/pm:spec-sync $FEATURE_NAME`"
 
 ## Prerequisites
 - Spec must exist with a `## Task Breakdown` section
-- Run `/pm:spec-plan $ARGUMENTS` first if the section is missing
+- Run `/pm:spec-plan $FEATURE_NAME` first if the section is missing

--- a/plugins/pm/skills/spec-next/SKILL.md
+++ b/plugins/pm/skills/spec-next/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: spec-next
+description: Finds the next actionable task in a SPEC.md by checking GitHub Issue status and resolving dependencies. Use when the user wants to know what to work on next.
+---
+
+# Spec Next
+
+Reads `.claude/specs/$ARGUMENTS.md`, fetches live issue status from GitHub, and identifies the next task(s) that are ready to work on — open issues whose dependencies are all closed.
+
+## Preflight
+
+!`
+SPEC=".claude/specs/$ARGUMENTS.md"
+
+if [ -z "$ARGUMENTS" ]; then
+  echo "[ERROR] No feature name provided. Usage: /pm:spec-next <feature-name>"
+  if [ -d ".claude/specs" ]; then
+    echo ""
+    echo "Available specs:"
+    for f in .claude/specs/*.md; do
+      [ -f "$f" ] && echo "  • $(basename "$f" .md)"
+    done
+  fi
+  exit 1
+fi
+
+if [ ! -f "$SPEC" ]; then
+  echo "[ERROR] Spec not found: $SPEC"
+  if [ -d ".claude/specs" ]; then
+    echo ""
+    echo "Available specs:"
+    for f in .claude/specs/*.md; do
+      [ -f "$f" ] && echo "  • $(basename "$f" .md)"
+    done
+  fi
+  exit 1
+fi
+
+echo "--- Spec content ---"
+cat "$SPEC"
+echo ""
+
+echo "--- Live issue statuses ---"
+grep "issue_url:" "$SPEC" | grep "https" | sed 's/.*issue_url: *"//' | sed 's/"//' | while read url; do
+  issue_num=$(echo "$url" | grep -oE '[0-9]+$')
+  if [ -n "$issue_num" ]; then
+    gh issue view "$issue_num" --json number,title,state,labels \
+      -q '"#\(.number) [\(.state | ascii_upcase)] \(.title)"' 2>/dev/null || echo "#$issue_num [ERROR] Could not fetch"
+  fi
+done
+`
+
+## Instructions
+
+Using the spec content and live issue statuses fetched above, find the next task(s) ready to work on.
+
+### Algorithm
+
+1. Parse the `tasks:` list from the spec frontmatter (1-based index order).
+2. For each task, determine its status:
+   - `CLOSED` — issue state is `CLOSED`
+   - `OPEN` — issue state is `OPEN`
+   - `unsynced` — task has no `issue_url`
+3. Build a dependency map: each task's `depends_on` field lists 1-based indices of tasks it depends on.
+4. A task is **ready** if:
+   - Its status is `OPEN` or `unsynced`
+   - Every task listed in its `depends_on` has status `CLOSED`
+5. A task is **blocked** if any dependency is `OPEN` or `unsynced`.
+
+### Output Format
+
+```
+## Next Task(s) for: $ARGUMENTS
+
+### ✅ Ready to Work On
+- #<issue> <title> — <issue_url>
+  Tags: <tags>
+
+### ⏳ Blocked
+- #<issue> <title> — waiting on: <dependency titles>
+
+### 💡 Suggestion
+<one-line recommendation on what to pick up next>
+```
+
+Rules:
+- If no tasks are ready and none are blocked, show: "🎉 All tasks complete!"
+- If tasks are unsynced (no issue), suggest running `/pm:spec-sync $ARGUMENTS` first.
+- If multiple tasks are ready, list all of them — the user picks.
+- "Suggestion" should recommend the highest-priority ready task based on tags or position in the list.
+
+## Prerequisites
+- Spec must exist at `.claude/specs/$ARGUMENTS.md`
+- GitHub CLI authenticated for live issue fetching


### PR DESCRIPTION
## Summary

Adds two enhancements to the `pm` plugin for spec-driven project management.

### Changes

- **New skill: `/pm:spec-next <feature-name>`** — finds the next actionable task(s) in a spec by fetching live GitHub Issue statuses and resolving the `depends_on` dependency graph. Outputs ready tasks (open with all deps closed), blocked tasks, and a suggestion on what to pick up next.
- **`/pm:spec-decompose` `--granularity micro|pr|macro`** — adds the same granularity flag as `spec-plan` to control how the task breakdown table is split into frontmatter tasks. Auto-detects granularity from the spec comment written by `spec-plan` when the flag is omitted.
- Updated `README.md` to document both changes and add `spec-next` to the workflow diagram.

## Related Issues

<!-- Link related issues using #issue_number or "Closes #issue_number" to auto-close -->

## Testing

- [ ] Tested locally
- [ ] Docker build/container works (if applicable)
- [ ] Manual testing completed

## Checklist

- [ ] Code follows project conventions (shell script style, Python formatting)
- [x] Documentation updated (README.md, CLAUDE.md, or relevant docs)
- [x] No breaking changes (or clearly documented with migration guide if unavoidable)
- [ ] GitHub Actions workflows pass (if modified)
- [x] Commit messages are clear and follow conventional commit style