### PR TITLE
fix: replace session@codemate with workspace@codemate in DEFAULT_PLUGINS

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN echo "* * * * * agent /usr/local/bin/setup/shell/monitor-pr.sh >> /tmp/pr-mo
 
 # Environment variables for plugin configuration
 ENV DEFAULT_MARKETPLACES="vercel-labs/agent-browser,BoringHappy/CodeMate"
-ENV DEFAULT_PLUGINS="agent-browser@agent-browser,git@codemate,pr@codemate,dev@codemate,issue@codemate,session@codemate,pm@codemate"
+ENV DEFAULT_PLUGINS="agent-browser@agent-browser,git@codemate,pr@codemate,dev@codemate,issue@codemate,workspace@codemate,pm@codemate"
 
 # Switch to agent user and install Claude Code
 USER agent


### PR DESCRIPTION
## Summary

The `DEFAULT_PLUGINS` env var in the Dockerfile referenced `session@codemate`, which does not exist. Session lifecycle functionality (tracking SessionStart, UserPromptSubmit, and Stop events) is provided by the `workspace` plugin. This fixes the plugin name so the correct plugin is installed at container startup.

### Changes

- `docker/Dockerfile`: Replace `session@codemate` with `workspace@codemate` in `DEFAULT_PLUGINS`

## Related Issues

N/A

## Testing

- [ ] Tested locally
- [x] Docker build/container works (if applicable)
- [ ] Manual testing completed

## Checklist

- [x] Code follows project conventions (shell script style, Python formatting)
- [ ] Documentation updated (README.md, CLAUDE.md, or relevant docs)
- [x] No breaking changes (or clearly documented with migration guide if unavoidable)
- [ ] GitHub Actions workflows pass (if modified)
- [x] Commit messages are clear and follow conventional commit style