### PR TITLE
fix: prevent infinite block loop in check_git_changes Stop hook

### DIFF
--- a/plugins/workspace/hooks/check_git_changes.sh
+++ b/plugins/workspace/hooks/check_git_changes.sh
@@ -1,18 +1,45 @@
 #!/bin/bash
 # Check for uncommitted git changes and inject a commit prompt if found.
 # Works both as a standalone Stop hook and when sourced by monitor_pr.sh.
+#
+# Uses a counter file to avoid infinite blocking loops: after MAX_BLOCKS
+# consecutive blocks without changes being committed, it downgrades to a
+# warning so Claude can actually stop.
+
+BLOCK_COUNTER_FILE="/tmp/.git_changes_block_count"
+MAX_BLOCKS=2
 
 _git_changes_inject() {
     printf '{"decision":"block","reason":"Please use /git:commit skill to submit changes to github"}'
 }
 
+_git_changes_warn() {
+    printf '{"decision":"warn","reason":"Uncommitted changes remain. Use /git:commit to push them to github."}'
+}
+
 check_git_changes() {
     local git_changes
     git_changes=$(git status --porcelain 2>/dev/null || echo "")
-    if [ -n "$git_changes" ]; then
-        _git_changes_inject
-        exit 0
+
+    if [ -z "$git_changes" ]; then
+        # Clean — reset counter
+        rm -f "$BLOCK_COUNTER_FILE"
+        return
     fi
+
+    # Read current block count
+    local count=0
+    [ -f "$BLOCK_COUNTER_FILE" ] && count=$(cat "$BLOCK_COUNTER_FILE")
+
+    if [ "$count" -lt "$MAX_BLOCKS" ]; then
+        echo $((count + 1)) > "$BLOCK_COUNTER_FILE"
+        _git_changes_inject
+    else
+        # Exceeded max blocks — warn instead of block to avoid infinite loop
+        rm -f "$BLOCK_COUNTER_FILE"
+        _git_changes_warn
+    fi
+    exit 0
 }
 
 # Run directly when executed as a standalone hook


### PR DESCRIPTION
## Summary

The `check_git_changes.sh` Stop hook would unconditionally block Claude from stopping whenever uncommitted changes were present. Since blocking prevents Claude from responding, this created an infinite loop where Claude could never instruct the user to commit.

### Changes

- `plugins/workspace/hooks/check_git_changes.sh`: Added a session-scoped counter (`/tmp/.git_changes_block_count`) to track consecutive blocks. After `MAX_BLOCKS` (2) unresolved blocks, the hook downgrades from `block` to `warn`, allowing Claude to stop while still surfacing the uncommitted changes notice. Counter resets automatically when the working tree is clean.

## Related Issues

N/A

## Testing

- [ ] Tested locally
- [ ] Docker build/container works (if applicable)
- [ ] Manual testing completed

## Checklist

- [x] Code follows project conventions (shell script style, Python formatting)
- [ ] Documentation updated (README.md, CLAUDE.md, or relevant docs)
- [x] No breaking changes (or clearly documented with migration guide if unavoidable)
- [ ] GitHub Actions workflows pass (if modified)
- [x] Commit messages are clear and follow conventional commit style