### PR TITLE
fix(pm): fix BASE_DIR not set in spec skill preflight commands

### DIFF
--- a/plugins/pm/skills/spec-decompose/SKILL.md
+++ b/plugins/pm/skills/spec-decompose/SKILL.md
@@ -14,7 +14,7 @@ Usage: `/pm:spec-decompose <issue-number> [--granularity micro|pr|macro]`
 
 !`if [ -z "$ARGUMENTS" ]; then echo "[ERROR] No issue number provided. Usage: /pm:spec-decompose <issue-number> [--granularity micro|pr|macro]"; exit 1; fi`
 
-!`source "$BASE_DIR/../scripts/helpers.sh"; ARG=$(echo "$ARGUMENTS" | awk '{print $1}'); GRAN=""; if echo "$ARGUMENTS" | grep -q -- '--granularity'; then GRAN=$(parse_granularity "$ARGUMENTS") || exit 1; echo "[INFO] Granularity override: $GRAN"; fi; spec_decompose_fetch_issue "$ARG" "$GRAN"`
+!`_H=$(find ~/.claude/plugins/cache/codemate/pm -name "helpers.sh" -path "*/spec-decompose/scripts/*" | head -1); source "$_H"; ARG=$(echo "$ARGUMENTS" | awk '{print $1}'); GRAN=""; if echo "$ARGUMENTS" | grep -q -- '--granularity'; then GRAN=$(parse_granularity "$ARGUMENTS") || exit 1; echo "[INFO] Granularity override: $GRAN"; fi; spec_decompose_fetch_issue "$ARG" "$GRAN"`
 
 ## Instructions
 
@@ -42,7 +42,7 @@ Usage: `/pm:spec-decompose <issue-number> [--granularity micro|pr|macro]`
 
 4. **Ensure labels exist**:
    ```bash
-   source "$BASE_DIR/../scripts/helpers.sh"
+   source "$BASE_DIR/scripts/helpers.sh"
    SPEC_LABEL=$(gh issue view <spec_issue_number> --json labels --jq '[.labels[].name | select(startswith("spec:"))] | .[0]')
    ensure_task_labels "${SPEC_LABEL#spec:}"
    ```
@@ -56,7 +56,7 @@ Usage: `/pm:spec-decompose <issue-number> [--granularity micro|pr|macro]`
 
    b. Remove it from the spec issue's sub-issues:
    ```bash
-   source "$BASE_DIR/../scripts/helpers.sh"
+   source "$BASE_DIR/scripts/helpers.sh"
    remove_sub_issue "$REPO" "$SPEC_ISSUE_NUMBER" "<orphan_issue_id>"
    ```
 
@@ -75,7 +75,7 @@ Usage: `/pm:spec-decompose <issue-number> [--granularity micro|pr|macro]`
 
    b. Write the task body to a temp file and create the issue:
    ```bash
-   source "$BASE_DIR/../scripts/helpers.sh"
+   source "$BASE_DIR/scripts/helpers.sh"
    SPEC_LABEL=$(gh issue view <spec_issue_number> --json labels --jq '[.labels[].name | select(startswith("spec:"))] | .[0]')
    write_issue_body "<body content>" /tmp/task-body.md
 
@@ -95,13 +95,13 @@ Usage: `/pm:spec-decompose <issue-number> [--granularity micro|pr|macro]`
 
    d. Register as sub-issue of the spec issue:
    ```bash
-   source "$BASE_DIR/../scripts/helpers.sh"
+   source "$BASE_DIR/scripts/helpers.sh"
    register_sub_issue "$REPO" "$SPEC_ISSUE_NUMBER" "$TASK_ISSUE_ID"
    ```
 
 7. **Add `ready` label** to the spec issue:
    ```bash
-   source "$BASE_DIR/../scripts/helpers.sh"
+   source "$BASE_DIR/scripts/helpers.sh"
    ensure_ready_label
    gh issue edit $SPEC_ISSUE_NUMBER --add-label "ready"
    ```

--- a/plugins/pm/skills/spec-decompose/scripts/helpers.sh
+++ b/plugins/pm/skills/spec-decompose/scripts/helpers.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# Shared helpers for pm spec skills
+# Expected layout: plugins/pm/scripts/helpers.sh
+# Source from a skill with: source "$BASE_DIR/../scripts/helpers.sh"
+# ($BASE_DIR is set by the skill runner to the skill's own directory)
+
+# Parse and validate granularity from ARGUMENTS string
+# Prints the resolved granularity value (micro|pr|macro) or errors and returns 1
+# Usage: parse_granularity "$ARGUMENTS"
+parse_granularity() {
+  local args="$1"
+  local granularity
+  granularity=$(echo "$args" | sed -n 's/.*--granularity[[:space:]]\+\([^[:space:]]\+\).*/\1/p')
+  granularity="${granularity:-pr}"
+  case "$granularity" in
+    micro|pr|macro) echo "$granularity" ;;
+    *) echo "[ERROR] Invalid granularity: '$granularity'. Must be one of: micro, pr, macro" >&2; return 1 ;;
+  esac
+}
+
+# Fetch spec issue and print body for spec-plan preflight
+# Usage: spec_plan_fetch_issue <issue-number>
+spec_plan_fetch_issue() {
+  local arg="$1"
+  echo "--- Fetching spec issue ---"
+  local spec
+  spec=$(gh issue view "$arg" --json number,title,url,body,state 2>/dev/null)
+  if [ -z "$spec" ] || [ "$spec" = "null" ]; then
+    echo "[ERROR] Issue #$arg not found"
+    return 1
+  fi
+  printf '%s' "$spec" | jq -r '"[OK] Found spec issue #\(.number): \(.url)"'
+  if printf '%s' "$spec" | jq -r '.body' | grep -q "## Architecture Decisions"; then
+    echo "[WARN] Plan sections already exist in spec issue"
+  else
+    echo "[OK] Ready to plan"
+  fi
+  echo ""
+  echo "--- Current spec issue body ---"
+  printf '%s' "$spec" | jq -r '.body'
+}
+
+# Fetch spec issue and print body for spec-decompose preflight
+# Usage: spec_decompose_fetch_issue <issue-number> [granularity-override]
+spec_decompose_fetch_issue() {
+  local arg="$1"
+  local gran_override="$2"
+  echo "--- Fetching spec issue ---"
+  local spec
+  spec=$(gh issue view "$arg" --json number,title,url,body,state,labels 2>/dev/null)
+  if [ -z "$spec" ] || [ "$spec" = "null" ]; then
+    echo "[ERROR] Issue #$arg not found"
+    return 1
+  fi
+  local spec_num spec_url spec_label spec_body detected gran repo
+  spec_num=$(printf '%s' "$spec" | jq -r '.number')
+  spec_url=$(printf '%s' "$spec" | jq -r '.url')
+  spec_label=$(printf '%s' "$spec" | jq -r '[.labels[].name | select(startswith("spec:"))] | .[0]')
+  echo "[OK] Found spec issue #$spec_num: $spec_url"
+  spec_body=$(printf '%s' "$spec" | jq -r '.body')
+  if ! printf '%s' "$spec_body" | grep -q "## Task Breakdown"; then
+    echo "[ERROR] No Task Breakdown section found. Run /pm:spec-plan $arg first."
+    return 1
+  fi
+  detected=$(printf '%s' "$spec_body" | grep -m1 '<!-- granularity:' | sed 's/.*granularity: *\([^ >]*\).*/\1/')
+  gran="${gran_override:-${detected:-pr}}"
+  echo "[INFO] Granularity: $gran | Label: $spec_label"
+  repo=$(gh repo view --json nameWithOwner -q '.nameWithOwner')
+  echo "[INFO] Repo: $repo | Spec issue: #$spec_num"
+  echo ""
+  echo "--- Existing sub-issues ---"
+  gh api \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "/repos/$repo/issues/$spec_num/sub_issues" \
+    --jq '.[] | "  #\(.number) [\(.state)] \(.title)"' 2>/dev/null || echo "  None"
+  echo ""
+  echo "--- Spec issue body ---"
+  printf '%s\n' "$spec_body"
+}
+
+# Ensure required labels exist for a spec
+# Usage: ensure_spec_labels <feature-name>
+ensure_spec_labels() {
+  local name="$1"
+  gh label create "spec" --color "5319E7" --description "Spec-level tracking issue" --force 2>/dev/null || true
+  gh label create "spec:$name" --color "0E8A16" --description "Part of spec: $name" --force 2>/dev/null || true
+}
+
+# Ensure required labels exist for tasks
+# Usage: ensure_task_labels <feature-name>
+ensure_task_labels() {
+  local name="$1"
+  gh label create "task" --color "1D76DB" --description "Task from spec" --force 2>/dev/null || true
+  gh label create "spec:$name" --color "0E8A16" --description "Part of spec: $name" --force 2>/dev/null || true
+}
+
+# Ensure planned label exists
+ensure_planned_label() {
+  gh label create "planned" --color "FBCA04" --description "Spec has a technical plan" --force 2>/dev/null || true
+}
+
+# Ensure ready label exists
+ensure_ready_label() {
+  gh label create "ready" --color "0075CA" --description "Spec tasks have been decomposed" --force 2>/dev/null || true
+}
+
+# Write issue body to temp file and create/edit a GitHub issue
+# Usage: write_issue_body <content> <tempfile>
+write_issue_body() {
+  local content="$1"
+  local tmpfile="$2"
+  printf '%s' "$content" > "$tmpfile"
+}
+
+# Get repo nameWithOwner
+# Usage: get_repo
+get_repo() {
+  gh repo view --json nameWithOwner -q '.nameWithOwner'
+}
+
+# Register a sub-issue under a parent spec issue
+# Usage: register_sub_issue <repo> <spec_issue_number> <task_issue_id>
+register_sub_issue() {
+  local repo="$1"
+  local spec_num="$2"
+  local task_id="$3"
+  gh api \
+    --method POST \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "/repos/$repo/issues/$spec_num/sub_issues" \
+    -f sub_issue_id="$task_id"
+}
+
+# Remove a sub-issue from a parent spec issue
+# Usage: remove_sub_issue <repo> <spec_issue_number> <task_issue_id>
+remove_sub_issue() {
+  local repo="$1"
+  local spec_num="$2"
+  local task_id="$3"
+  gh api \
+    --method DELETE \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "/repos/$repo/issues/$spec_num/sub_issues" \
+    -f sub_issue_id="$task_id"
+}
+
+# List sub-issues for a spec issue
+# Usage: list_sub_issues <repo> <spec_issue_number>
+list_sub_issues() {
+  local repo="$1"
+  local spec_num="$2"
+  gh api \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "/repos/$repo/issues/$spec_num/sub_issues" \
+    --jq '.' 2>/dev/null || echo "[]"
+}

--- a/plugins/pm/skills/spec-init/SKILL.md
+++ b/plugins/pm/skills/spec-init/SKILL.md
@@ -32,7 +32,7 @@ Usage: `/pm:spec-init <short-title>`
 
 3. **Derive the label slug** from the title and ensure labels exist:
    ```bash
-   source "$BASE_DIR/../scripts/helpers.sh"
+   source "$BASE_DIR/scripts/helpers.sh"
    LABEL=$(echo "$ARGUMENTS" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/-\+/-/g' | sed 's/^-\|-$//g')
    ensure_spec_labels "$LABEL"
    ```
@@ -40,7 +40,7 @@ Usage: `/pm:spec-init <short-title>`
 4. **Create the spec issue** — write the body to a temp file, then create the issue. If a spec template was found in preflight, mirror its section headings exactly. Otherwise use the default format below:
 
    ```bash
-   source "$BASE_DIR/../scripts/helpers.sh"
+   source "$BASE_DIR/scripts/helpers.sh"
    write_issue_body "<body content>" /tmp/spec-body.md
 
    gh issue create \

--- a/plugins/pm/skills/spec-init/scripts/helpers.sh
+++ b/plugins/pm/skills/spec-init/scripts/helpers.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# Shared helpers for pm spec skills
+# Expected layout: plugins/pm/scripts/helpers.sh
+# Source from a skill with: source "$BASE_DIR/../scripts/helpers.sh"
+# ($BASE_DIR is set by the skill runner to the skill's own directory)
+
+# Parse and validate granularity from ARGUMENTS string
+# Prints the resolved granularity value (micro|pr|macro) or errors and returns 1
+# Usage: parse_granularity "$ARGUMENTS"
+parse_granularity() {
+  local args="$1"
+  local granularity
+  granularity=$(echo "$args" | sed -n 's/.*--granularity[[:space:]]\+\([^[:space:]]\+\).*/\1/p')
+  granularity="${granularity:-pr}"
+  case "$granularity" in
+    micro|pr|macro) echo "$granularity" ;;
+    *) echo "[ERROR] Invalid granularity: '$granularity'. Must be one of: micro, pr, macro" >&2; return 1 ;;
+  esac
+}
+
+# Fetch spec issue and print body for spec-plan preflight
+# Usage: spec_plan_fetch_issue <issue-number>
+spec_plan_fetch_issue() {
+  local arg="$1"
+  echo "--- Fetching spec issue ---"
+  local spec
+  spec=$(gh issue view "$arg" --json number,title,url,body,state 2>/dev/null)
+  if [ -z "$spec" ] || [ "$spec" = "null" ]; then
+    echo "[ERROR] Issue #$arg not found"
+    return 1
+  fi
+  printf '%s' "$spec" | jq -r '"[OK] Found spec issue #\(.number): \(.url)"'
+  if printf '%s' "$spec" | jq -r '.body' | grep -q "## Architecture Decisions"; then
+    echo "[WARN] Plan sections already exist in spec issue"
+  else
+    echo "[OK] Ready to plan"
+  fi
+  echo ""
+  echo "--- Current spec issue body ---"
+  printf '%s' "$spec" | jq -r '.body'
+}
+
+# Fetch spec issue and print body for spec-decompose preflight
+# Usage: spec_decompose_fetch_issue <issue-number> [granularity-override]
+spec_decompose_fetch_issue() {
+  local arg="$1"
+  local gran_override="$2"
+  echo "--- Fetching spec issue ---"
+  local spec
+  spec=$(gh issue view "$arg" --json number,title,url,body,state,labels 2>/dev/null)
+  if [ -z "$spec" ] || [ "$spec" = "null" ]; then
+    echo "[ERROR] Issue #$arg not found"
+    return 1
+  fi
+  local spec_num spec_url spec_label spec_body detected gran repo
+  spec_num=$(printf '%s' "$spec" | jq -r '.number')
+  spec_url=$(printf '%s' "$spec" | jq -r '.url')
+  spec_label=$(printf '%s' "$spec" | jq -r '[.labels[].name | select(startswith("spec:"))] | .[0]')
+  echo "[OK] Found spec issue #$spec_num: $spec_url"
+  spec_body=$(printf '%s' "$spec" | jq -r '.body')
+  if ! printf '%s' "$spec_body" | grep -q "## Task Breakdown"; then
+    echo "[ERROR] No Task Breakdown section found. Run /pm:spec-plan $arg first."
+    return 1
+  fi
+  detected=$(printf '%s' "$spec_body" | grep -m1 '<!-- granularity:' | sed 's/.*granularity: *\([^ >]*\).*/\1/')
+  gran="${gran_override:-${detected:-pr}}"
+  echo "[INFO] Granularity: $gran | Label: $spec_label"
+  repo=$(gh repo view --json nameWithOwner -q '.nameWithOwner')
+  echo "[INFO] Repo: $repo | Spec issue: #$spec_num"
+  echo ""
+  echo "--- Existing sub-issues ---"
+  gh api \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "/repos/$repo/issues/$spec_num/sub_issues" \
+    --jq '.[] | "  #\(.number) [\(.state)] \(.title)"' 2>/dev/null || echo "  None"
+  echo ""
+  echo "--- Spec issue body ---"
+  printf '%s\n' "$spec_body"
+}
+
+# Ensure required labels exist for a spec
+# Usage: ensure_spec_labels <feature-name>
+ensure_spec_labels() {
+  local name="$1"
+  gh label create "spec" --color "5319E7" --description "Spec-level tracking issue" --force 2>/dev/null || true
+  gh label create "spec:$name" --color "0E8A16" --description "Part of spec: $name" --force 2>/dev/null || true
+}
+
+# Ensure required labels exist for tasks
+# Usage: ensure_task_labels <feature-name>
+ensure_task_labels() {
+  local name="$1"
+  gh label create "task" --color "1D76DB" --description "Task from spec" --force 2>/dev/null || true
+  gh label create "spec:$name" --color "0E8A16" --description "Part of spec: $name" --force 2>/dev/null || true
+}
+
+# Ensure planned label exists
+ensure_planned_label() {
+  gh label create "planned" --color "FBCA04" --description "Spec has a technical plan" --force 2>/dev/null || true
+}
+
+# Ensure ready label exists
+ensure_ready_label() {
+  gh label create "ready" --color "0075CA" --description "Spec tasks have been decomposed" --force 2>/dev/null || true
+}
+
+# Write issue body to temp file and create/edit a GitHub issue
+# Usage: write_issue_body <content> <tempfile>
+write_issue_body() {
+  local content="$1"
+  local tmpfile="$2"
+  printf '%s' "$content" > "$tmpfile"
+}
+
+# Get repo nameWithOwner
+# Usage: get_repo
+get_repo() {
+  gh repo view --json nameWithOwner -q '.nameWithOwner'
+}
+
+# Register a sub-issue under a parent spec issue
+# Usage: register_sub_issue <repo> <spec_issue_number> <task_issue_id>
+register_sub_issue() {
+  local repo="$1"
+  local spec_num="$2"
+  local task_id="$3"
+  gh api \
+    --method POST \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "/repos/$repo/issues/$spec_num/sub_issues" \
+    -f sub_issue_id="$task_id"
+}
+
+# Remove a sub-issue from a parent spec issue
+# Usage: remove_sub_issue <repo> <spec_issue_number> <task_issue_id>
+remove_sub_issue() {
+  local repo="$1"
+  local spec_num="$2"
+  local task_id="$3"
+  gh api \
+    --method DELETE \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "/repos/$repo/issues/$spec_num/sub_issues" \
+    -f sub_issue_id="$task_id"
+}
+
+# List sub-issues for a spec issue
+# Usage: list_sub_issues <repo> <spec_issue_number>
+list_sub_issues() {
+  local repo="$1"
+  local spec_num="$2"
+  gh api \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "/repos/$repo/issues/$spec_num/sub_issues" \
+    --jq '.' 2>/dev/null || echo "[]"
+}

--- a/plugins/pm/skills/spec-plan/SKILL.md
+++ b/plugins/pm/skills/spec-plan/SKILL.md
@@ -14,9 +14,9 @@ Usage: `/pm:spec-plan <issue-number> [--granularity micro|pr|macro]`
 
 !`if [ -z "$ARGUMENTS" ]; then echo "[ERROR] No issue number provided. Usage: /pm:spec-plan <issue-number> [--granularity micro|pr|macro]"; exit 1; fi`
 
-!`source "$BASE_DIR/../scripts/helpers.sh"; GRANULARITY=$(parse_granularity "$ARGUMENTS") || exit 1; echo "[INFO] Granularity: $GRANULARITY"`
+!`_H=$(find ~/.claude/plugins/cache/codemate/pm -name "helpers.sh" -path "*/spec-plan/scripts/*" | head -1); source "$_H"; GRANULARITY=$(parse_granularity "$ARGUMENTS") || exit 1; echo "[INFO] Granularity: $GRANULARITY"`
 
-!`source "$BASE_DIR/../scripts/helpers.sh"; spec_plan_fetch_issue "$(echo "$ARGUMENTS" | awk '{print $1}')"`
+!`_H=$(find ~/.claude/plugins/cache/codemate/pm -name "helpers.sh" -path "*/spec-plan/scripts/*" | head -1); source "$_H"; spec_plan_fetch_issue "$(echo "$ARGUMENTS" | awk '{print $1}')"`
 
 ## Instructions
 
@@ -39,7 +39,7 @@ Usage: `/pm:spec-plan <issue-number> [--granularity micro|pr|macro]`
 4. **Write the updated body to a temp file and update the spec issue** to avoid shell escaping issues:
 
    ```bash
-   source "$BASE_DIR/../scripts/helpers.sh"
+   source "$BASE_DIR/scripts/helpers.sh"
    write_issue_body "<full updated body with plan sections appended>" /tmp/spec-plan-body.md
    gh issue edit <spec_issue_number> --body-file /tmp/spec-plan-body.md
    rm -f /tmp/spec-plan-body.md
@@ -80,7 +80,7 @@ Usage: `/pm:spec-plan <issue-number> [--granularity micro|pr|macro]`
 
 5. **Add `planned` label** to the spec issue:
    ```bash
-   source "$BASE_DIR/../scripts/helpers.sh"
+   source "$BASE_DIR/scripts/helpers.sh"
    ensure_planned_label
    gh issue edit <spec_issue_number> --add-label "planned"
    ```

--- a/plugins/pm/skills/spec-plan/scripts/helpers.sh
+++ b/plugins/pm/skills/spec-plan/scripts/helpers.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# Shared helpers for pm spec skills
+# Expected layout: plugins/pm/scripts/helpers.sh
+# Source from a skill with: source "$BASE_DIR/../scripts/helpers.sh"
+# ($BASE_DIR is set by the skill runner to the skill's own directory)
+
+# Parse and validate granularity from ARGUMENTS string
+# Prints the resolved granularity value (micro|pr|macro) or errors and returns 1
+# Usage: parse_granularity "$ARGUMENTS"
+parse_granularity() {
+  local args="$1"
+  local granularity
+  granularity=$(echo "$args" | sed -n 's/.*--granularity[[:space:]]\+\([^[:space:]]\+\).*/\1/p')
+  granularity="${granularity:-pr}"
+  case "$granularity" in
+    micro|pr|macro) echo "$granularity" ;;
+    *) echo "[ERROR] Invalid granularity: '$granularity'. Must be one of: micro, pr, macro" >&2; return 1 ;;
+  esac
+}
+
+# Fetch spec issue and print body for spec-plan preflight
+# Usage: spec_plan_fetch_issue <issue-number>
+spec_plan_fetch_issue() {
+  local arg="$1"
+  echo "--- Fetching spec issue ---"
+  local spec
+  spec=$(gh issue view "$arg" --json number,title,url,body,state 2>/dev/null)
+  if [ -z "$spec" ] || [ "$spec" = "null" ]; then
+    echo "[ERROR] Issue #$arg not found"
+    return 1
+  fi
+  printf '%s' "$spec" | jq -r '"[OK] Found spec issue #\(.number): \(.url)"'
+  if printf '%s' "$spec" | jq -r '.body' | grep -q "## Architecture Decisions"; then
+    echo "[WARN] Plan sections already exist in spec issue"
+  else
+    echo "[OK] Ready to plan"
+  fi
+  echo ""
+  echo "--- Current spec issue body ---"
+  printf '%s' "$spec" | jq -r '.body'
+}
+
+# Fetch spec issue and print body for spec-decompose preflight
+# Usage: spec_decompose_fetch_issue <issue-number> [granularity-override]
+spec_decompose_fetch_issue() {
+  local arg="$1"
+  local gran_override="$2"
+  echo "--- Fetching spec issue ---"
+  local spec
+  spec=$(gh issue view "$arg" --json number,title,url,body,state,labels 2>/dev/null)
+  if [ -z "$spec" ] || [ "$spec" = "null" ]; then
+    echo "[ERROR] Issue #$arg not found"
+    return 1
+  fi
+  local spec_num spec_url spec_label spec_body detected gran repo
+  spec_num=$(printf '%s' "$spec" | jq -r '.number')
+  spec_url=$(printf '%s' "$spec" | jq -r '.url')
+  spec_label=$(printf '%s' "$spec" | jq -r '[.labels[].name | select(startswith("spec:"))] | .[0]')
+  echo "[OK] Found spec issue #$spec_num: $spec_url"
+  spec_body=$(printf '%s' "$spec" | jq -r '.body')
+  if ! printf '%s' "$spec_body" | grep -q "## Task Breakdown"; then
+    echo "[ERROR] No Task Breakdown section found. Run /pm:spec-plan $arg first."
+    return 1
+  fi
+  detected=$(printf '%s' "$spec_body" | grep -m1 '<!-- granularity:' | sed 's/.*granularity: *\([^ >]*\).*/\1/')
+  gran="${gran_override:-${detected:-pr}}"
+  echo "[INFO] Granularity: $gran | Label: $spec_label"
+  repo=$(gh repo view --json nameWithOwner -q '.nameWithOwner')
+  echo "[INFO] Repo: $repo | Spec issue: #$spec_num"
+  echo ""
+  echo "--- Existing sub-issues ---"
+  gh api \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "/repos/$repo/issues/$spec_num/sub_issues" \
+    --jq '.[] | "  #\(.number) [\(.state)] \(.title)"' 2>/dev/null || echo "  None"
+  echo ""
+  echo "--- Spec issue body ---"
+  printf '%s\n' "$spec_body"
+}
+
+# Ensure required labels exist for a spec
+# Usage: ensure_spec_labels <feature-name>
+ensure_spec_labels() {
+  local name="$1"
+  gh label create "spec" --color "5319E7" --description "Spec-level tracking issue" --force 2>/dev/null || true
+  gh label create "spec:$name" --color "0E8A16" --description "Part of spec: $name" --force 2>/dev/null || true
+}
+
+# Ensure required labels exist for tasks
+# Usage: ensure_task_labels <feature-name>
+ensure_task_labels() {
+  local name="$1"
+  gh label create "task" --color "1D76DB" --description "Task from spec" --force 2>/dev/null || true
+  gh label create "spec:$name" --color "0E8A16" --description "Part of spec: $name" --force 2>/dev/null || true
+}
+
+# Ensure planned label exists
+ensure_planned_label() {
+  gh label create "planned" --color "FBCA04" --description "Spec has a technical plan" --force 2>/dev/null || true
+}
+
+# Ensure ready label exists
+ensure_ready_label() {
+  gh label create "ready" --color "0075CA" --description "Spec tasks have been decomposed" --force 2>/dev/null || true
+}
+
+# Write issue body to temp file and create/edit a GitHub issue
+# Usage: write_issue_body <content> <tempfile>
+write_issue_body() {
+  local content="$1"
+  local tmpfile="$2"
+  printf '%s' "$content" > "$tmpfile"
+}
+
+# Get repo nameWithOwner
+# Usage: get_repo
+get_repo() {
+  gh repo view --json nameWithOwner -q '.nameWithOwner'
+}
+
+# Register a sub-issue under a parent spec issue
+# Usage: register_sub_issue <repo> <spec_issue_number> <task_issue_id>
+register_sub_issue() {
+  local repo="$1"
+  local spec_num="$2"
+  local task_id="$3"
+  gh api \
+    --method POST \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "/repos/$repo/issues/$spec_num/sub_issues" \
+    -f sub_issue_id="$task_id"
+}
+
+# Remove a sub-issue from a parent spec issue
+# Usage: remove_sub_issue <repo> <spec_issue_number> <task_issue_id>
+remove_sub_issue() {
+  local repo="$1"
+  local spec_num="$2"
+  local task_id="$3"
+  gh api \
+    --method DELETE \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "/repos/$repo/issues/$spec_num/sub_issues" \
+    -f sub_issue_id="$task_id"
+}
+
+# List sub-issues for a spec issue
+# Usage: list_sub_issues <repo> <spec_issue_number>
+list_sub_issues() {
+  local repo="$1"
+  local spec_num="$2"
+  gh api \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "/repos/$repo/issues/$spec_num/sub_issues" \
+    --jq '.' 2>/dev/null || echo "[]"
+}


### PR DESCRIPTION
## Summary

`$BASE_DIR` is never set by the Claude Code skill runner, causing all `source "$BASE_DIR/../scripts/helpers.sh"` calls in `spec-plan`, `spec-decompose`, and `spec-init` preflight commands to fail with `no such file or directory: /../scripts/helpers.sh`.

### Changes

- `plugins/pm/skills/spec-plan/scripts/helpers.sh` — new per-skill copy of shared helpers
- `plugins/pm/skills/spec-decompose/scripts/helpers.sh` — new per-skill copy of shared helpers
- `plugins/pm/skills/spec-init/scripts/helpers.sh` — new per-skill copy of shared helpers
- `plugins/pm/skills/spec-plan/SKILL.md` — fix `!` preflight to resolve helpers via `find`; update `source` paths from `$BASE_DIR/../scripts/` to `$BASE_DIR/scripts/`
- `plugins/pm/skills/spec-decompose/SKILL.md` — same preflight and source path fixes
- `plugins/pm/skills/spec-init/SKILL.md` — update source paths to `$BASE_DIR/scripts/`

## Related Issues

Closes #189

## Testing

- [x] Tested locally
- [ ] Docker build/container works (if applicable)
- [x] Manual testing completed

## Checklist

- [x] Code follows project conventions (shell script style, Python formatting)
- [ ] Documentation updated (README.md, CLAUDE.md, or relevant docs)
- [x] No breaking changes (or clearly documented with migration guide if unavoidable)
- [ ] GitHub Actions workflows pass (if modified)
- [x] Commit messages are clear and follow conventional commit style