### PR TITLE
fix(pm): fix sub_issue_id sent as string instead of integer in helpers.sh

### DIFF
--- a/plugins/pm/scripts/helpers.sh
+++ b/plugins/pm/scripts/helpers.sh
@@ -130,7 +130,7 @@ register_sub_issue() {
     -H "Accept: application/vnd.github+json" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     "/repos/$repo/issues/$spec_num/sub_issues" \
-    -f sub_issue_id="$task_id"
+    -F sub_issue_id="$task_id"
 }
 
 # Remove a sub-issue from a parent spec issue
@@ -144,7 +144,7 @@ remove_sub_issue() {
     -H "Accept: application/vnd.github+json" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     "/repos/$repo/issues/$spec_num/sub_issues" \
-    -f sub_issue_id="$task_id"
+    -F sub_issue_id="$task_id"
 }
 
 # List sub-issues for a spec issue

--- a/plugins/pm/skills/spec-decompose/scripts/helpers.sh
+++ b/plugins/pm/skills/spec-decompose/scripts/helpers.sh
@@ -130,7 +130,7 @@ register_sub_issue() {
     -H "Accept: application/vnd.github+json" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     "/repos/$repo/issues/$spec_num/sub_issues" \
-    -f sub_issue_id="$task_id"
+    -F sub_issue_id="$task_id"
 }
 
 # Remove a sub-issue from a parent spec issue
@@ -144,7 +144,7 @@ remove_sub_issue() {
     -H "Accept: application/vnd.github+json" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     "/repos/$repo/issues/$spec_num/sub_issues" \
-    -f sub_issue_id="$task_id"
+    -F sub_issue_id="$task_id"
 }
 
 # List sub-issues for a spec issue

--- a/plugins/pm/skills/spec-init/scripts/helpers.sh
+++ b/plugins/pm/skills/spec-init/scripts/helpers.sh
@@ -130,7 +130,7 @@ register_sub_issue() {
     -H "Accept: application/vnd.github+json" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     "/repos/$repo/issues/$spec_num/sub_issues" \
-    -f sub_issue_id="$task_id"
+    -F sub_issue_id="$task_id"
 }
 
 # Remove a sub-issue from a parent spec issue
@@ -144,7 +144,7 @@ remove_sub_issue() {
     -H "Accept: application/vnd.github+json" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     "/repos/$repo/issues/$spec_num/sub_issues" \
-    -f sub_issue_id="$task_id"
+    -F sub_issue_id="$task_id"
 }
 
 # List sub-issues for a spec issue

--- a/plugins/pm/skills/spec-plan/scripts/helpers.sh
+++ b/plugins/pm/skills/spec-plan/scripts/helpers.sh
@@ -130,7 +130,7 @@ register_sub_issue() {
     -H "Accept: application/vnd.github+json" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     "/repos/$repo/issues/$spec_num/sub_issues" \
-    -f sub_issue_id="$task_id"
+    -F sub_issue_id="$task_id"
 }
 
 # Remove a sub-issue from a parent spec issue
@@ -144,7 +144,7 @@ remove_sub_issue() {
     -H "Accept: application/vnd.github+json" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     "/repos/$repo/issues/$spec_num/sub_issues" \
-    -f sub_issue_id="$task_id"
+    -F sub_issue_id="$task_id"
 }
 
 # List sub-issues for a spec issue


### PR DESCRIPTION
## Summary

Fix a bug in the `register_sub_issue` and `remove_sub_issue` helper functions where `sub_issue_id` was sent as a string instead of an integer, causing a GitHub API 422 error.

### Changes

- `plugins/pm/scripts/helpers.sh`: Changed `-f sub_issue_id` to `-F sub_issue_id` in `register_sub_issue` and `remove_sub_issue`
- `plugins/pm/skills/spec-decompose/scripts/helpers.sh`: Same fix
- `plugins/pm/skills/spec-init/scripts/helpers.sh`: Same fix
- `plugins/pm/skills/spec-plan/scripts/helpers.sh`: Same fix

The `gh api` `-f` flag always sends values as strings. The GitHub sub-issues API requires `sub_issue_id` to be an integer. Switching to `-F` lets `gh` infer the correct type.

## Related Issues

N/A

## Testing

- [x] Tested locally
- [ ] Docker build/container works (if applicable)
- [ ] Manual testing completed

## Checklist

- [x] Code follows project conventions (shell script style, Python formatting)
- [ ] Documentation updated (README.md, CLAUDE.md, or relevant docs)
- [x] No breaking changes (or clearly documented with migration guide if unavoidable)
- [ ] GitHub Actions workflows pass (if modified)
- [x] Commit messages are clear and follow conventional commit style