### PR TITLE
chore: add Related Spec section to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,11 @@
 
 -
 
+## Related Spec
+
+<!-- Link the parent spec issue: Implements #<spec-issue-number> -->
+<!-- Link the task this PR implements: Closes #<task-issue-number> -->
+
 ## Related Issues
 
 <!-- Link related issues using #issue_number or "Closes #issue_number" to auto-close -->


### PR DESCRIPTION
## Summary

Adds a `## Related Spec` section to the pull request template so contributors can link the parent spec issue and the task issue being implemented.

### Changes

- `.github/pull_request_template.md` — inserted `## Related Spec` section with placeholder comments for spec and task issue links

## Related Spec

<!-- Link the parent spec issue: Implements #<spec-issue-number> -->
<!-- Link the task this PR implements: Closes #<task-issue-number> -->

## Related Issues

<!-- Link related issues using #issue_number or "Closes #issue_number" to auto-close -->

## Testing

- [ ] Tested locally
- [ ] Docker build/container works (if applicable)
- [ ] Manual testing completed

## Checklist

- [ ] Code follows project conventions (shell script style, Python formatting)
- [ ] Documentation updated (README.md, CLAUDE.md, or relevant docs)
- [ ] No breaking changes (or clearly documented with migration guide if unavoidable)
- [ ] GitHub Actions workflows pass (if modified)
- [ ] Commit messages are clear and follow conventional commit style
